### PR TITLE
Feature/paginated get credentials

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -128,7 +128,7 @@ class mod_accredible_mod_form extends moodleform_mod {
 
         if($updatingcert) {
             // Grab existing certificates and cross-reference emails
-            $certificates = accredible_get_issued($accredible_certificate->achievementid);
+            $certificates = accredible_get_credentials($accredible_certificate->achievementid);
             foreach ($users as $user) {
                 $cert_id = null;
                 // check cert emails for this user

--- a/view.php
+++ b/view.php
@@ -53,6 +53,15 @@ if($accredible_certificate->achievementid){ // legacy achievment ID
 }
 
 if(has_capability('mod/accredible:manage', $context)) {
+	// User has admin privileges, show table of certificates.
+
+	// Get array of certificates
+	if($accredible_certificate->achievementid){ // legacy achievment ID
+		$certificates = accredible_get_credentials($accredible_certificate->achievementid);
+	} else { // group id
+		$certificates = accredible_get_credentials($accredible_certificate->groupid);
+	}
+
 	$table = new html_table();
 	$table->head  = array (get_string('id', 'accredible'), get_string('recipient', 'accredible'), get_string('certificateurl', 'accredible'), get_string('datecreated', 'accredible'));
 
@@ -81,8 +90,16 @@ if(has_capability('mod/accredible:manage', $context)) {
 	echo $OUTPUT->footer($course);
 } 
 else {
-	// Check for this user's certificate
+	// Regular user, Check for this user's certificate
 	$users_certificate_link = null;
+
+	// Get certificate
+	if($accredible_certificate->achievementid){ // legacy achievment ID
+		$certificates = accredible_get_credentials($accredible_certificate->achievementid, $USER->email);
+	} else { // group id
+		$certificates = accredible_get_credentials($accredible_certificate->groupid, $USER->email);
+	}
+
 	foreach ($certificates as $certificate) {
     if($certificate->recipient->email == $USER->email) {
       if($certificate->private) {

--- a/view.php
+++ b/view.php
@@ -47,7 +47,7 @@ $PAGE->set_heading(format_string($course->fullname));
 
 // Get array of certificates
 if($accredible_certificate->achievementid){ // legacy achievment ID
-	$certificates = accredible_get_issued($accredible_certificate->achievementid);
+	$certificates = accredible_get_credentials($accredible_certificate->achievementid);
 } else { // group id
 	$certificates = accredible_get_credentials($accredible_certificate->groupid);
 }


### PR DESCRIPTION
This PR moves everything over to using the get_credentials function (no more use of get_issued), adds pagination to the requests sent by get_credentials so it doesn't time out when trying to get all certificates for a popular course, and limits the credentials that are loaded when a normal user hits view.php (no need to load all the course certificates when they're just viewing their own certificate, it can take a looooong time). 