### PR TITLE
Replace pix_url() with image_url()

### DIFF
--- a/view.php
+++ b/view.php
@@ -120,7 +120,7 @@ else {
 	echo $OUTPUT->header();
 
 	if($users_certificate_link) {
-		$src = $OUTPUT->pix_url('complete_cert', 'accredible');
+		$src = $OUTPUT->image_url('complete_cert', 'accredible');
 		echo html_writer::start_div('text-center');
 		echo html_writer::tag( 'br', null );
 		if($certificates && $certificates[0] && $certificates[0]->seo_image){
@@ -133,7 +133,7 @@ else {
 		echo html_writer::end_div('text-center');
 	} 
 	else {
-		$src = $OUTPUT->pix_url('incomplete_cert', 'accredible');
+		$src = $OUTPUT->image_url('incomplete_cert', 'accredible');
 		echo html_writer::start_div('text-center');
 		echo html_writer::tag( 'br', null );
 		echo html_writer::img($src, get_string('viewimgincomplete', 'accredible'), array('width' => '90%') );


### PR DESCRIPTION
Deprecated in newer versions of moodle. I think image_url was introduced in v3.0, but I'd have to check. If you need to have compatibility with older versions before it was introduced here's how the hotpot guys did it https://github.com/gbateson/moodle-mod_hotpot/commit/890a50b1dba4e545094f8c7c2e325806703b6702