### PR TITLE
Resolves undefined $course, $users_earned_certificate

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -35,11 +35,11 @@ require_once($CFG->dirroot.'/mod/accredible/locallib.php');
 class mod_accredible_mod_form extends moodleform_mod {
 
     function definition() {
-        global $DB, $OUTPUT, $CFG;
+        global $DB, $OUTPUT, $CFG, $COURSE;
         $updatingcert = false;
         $alreadyexists = false;
 
-        $description = Html2Text\Html2Text::convert($course->summary);
+        $description = Html2Text\Html2Text::convert($COURSE->summary);
         if(empty($description)){
             $description = "Recipient has compeleted the achievement.";
         }
@@ -151,6 +151,7 @@ class mod_accredible_mod_form extends moodleform_mod {
         }
 
         // Unissued certificates header
+        $users_earned_certificate = [];
         if (count($users_earned_certificate) > 0) {
             $unissued_header = false;
             foreach ($users_earned_certificate as $user) {


### PR DESCRIPTION
mod_accredible fails on Moodle 3.9 with the errors below caused by each variable being undeclared before use.

Undefined variable: course in mod_form.php on line 42
Trying to get property 'summary' of non-object in mod_form.php on line 42
Undefined variable: users_earned_certificate in mod_form.php on line 154
count(): Parameter must be an array or an object that implements Countable in mod_form.php on line 154

Please check this out as part of preparing for your 3.9 release - hope it helps and turns up in the plugin repo soon. I haven't run into any other showstopping errors.

