### PR TITLE
Fix db/services.php wrong key names

### DIFF
--- a/db/services.php
+++ b/db/services.php
@@ -5,9 +5,9 @@ $functions = array(
 
 $services = array (
     'accredible service' => array(
-        'function' => array(
+        'functions' => array(
         ),
-        "restricteduser" => 0,
+        "restrictedusers" => 0,
         "enabled" => 1,
     )
 );

--- a/version.php
+++ b/version.php
@@ -24,10 +24,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version   = 2021061401; // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2021072601; // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2014051200; // Requires this Moodle version
 $plugin->cron      = 0; // Period for cron to check this module (secs)
 $plugin->component = 'mod_accredible';
 
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = "v1.7.0"; // User-friendly version number
+$plugin->release   = "v1.7.1"; // User-friendly version number


### PR DESCRIPTION
Pre-build services should not have `function` and `restricteduser` but `functions` and `restrictedusers`. Because of these wrong keys, the following warning messages are displayed when installing the plugin:

```
Notice: Undefined index: functions in /lib/upgradelib.php on line 1382
Warning: Invalid argument supplied for foreach() in /lib/upgradelib.php on line 1382
```

- Reference: https://docs.moodle.org/dev/Web_services_API
- The tested version: MOODLE_311_STABLE, PHP 7.3