### PR TITLE
Add api client error log

### DIFF
--- a/classes/client/client.php
+++ b/classes/client/client.php
@@ -34,6 +34,12 @@ class client {
         ));
 
         $response = curl_exec($curl);
+        $httpcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        if($httpcode >= 400) {
+            echo '<script>';
+            echo 'console.error("ACCREDIBLE API ERROR:", "' . $httpcode . '", "' . $method . '", "' . $url . '")';
+            echo '</script>';
+        }
 
         curl_close($curl);
 

--- a/classes/client/client.php
+++ b/classes/client/client.php
@@ -18,6 +18,9 @@ class client {
     }
 
     static function create_req($url, $token, $method, $postBody = null) {
+        global $CFG;
+        require_once($CFG->libdir . '/filelib.php');
+
         $curl = new \curl();
         $options = array(
             'CURLOPT_RETURNTRANSFER' => true,

--- a/classes/client/client.php
+++ b/classes/client/client.php
@@ -18,30 +18,37 @@ class client {
     }
 
     static function create_req($url, $token, $method, $postBody = null) {
-        $curl = curl_init();
+        $curl = new \curl();
+        $options = array(
+            'CURLOPT_RETURNTRANSFER' => true,
+            'CURLOPT_FAILONERROR'    => true,
+            'CURLOPT_HTTPHEADER'     => array(
+                'Authorization: Token '.$token,
+                'Content-Type: application/json; charset=utf-8'
+            )
+        );
 
-        curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
-
-        if (isset($postBody)) {
-            curl_setopt($curl, CURLOPT_POSTFIELDS, $postBody);
+        switch($method) {
+            case 'GET':
+                $response = $curl->get($url, $postBody, $options);
+                break;
+            case 'POST':
+                $response = $curl->post($url, $postBody, $options);
+                break;
+            case 'PUT':
+                $response = $curl->put($url, $postBody, $options);
+                break;
+            case 'DELETE':
+                $response = $curl->delete($url, $postBody, $options);
+                break;
+            default:
+                throw new \coding_exception('Invalid HTTP method');
         }
 
-        curl_setopt($curl, CURLOPT_HTTPHEADER, array(
-            'Authorization: Token '.$token,
-            'Content-Type: application/json; charset=utf-8'
-        ));
-
-        $response = curl_exec($curl);
-        $httpcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        if($httpcode >= 400) {
-            echo '<script>';
-            echo 'console.error("ACCREDIBLE API ERROR:", "' . $httpcode . '", "' . $method . '", "' . $url . '")';
-            echo '</script>';
-        }
-
-        curl_close($curl);
+        if($curl->error) {
+            debugging('<div style="padding-top: 70px; font-size: 0.9rem;"><b>ACCREDIBLE API ERROR</b> ' .
+                $curl->error . '<br />' . $method . ' ' . $url . '</div>', DEBUG_DEVELOPER);
+        };
 
         return json_decode($response);
     }


### PR DESCRIPTION
Added Accredible API error logs for debugging.

When a request fails, it will show the HTTP status code, the HTTP method, and the endpoint when using the DEVELOPER debugging mode.

This makes it easier to get more information for debugging from clients and faster to understand or replicate issues.

For example, if the error code is 401, the Customer Support can easily tell that client's token is invalid without additional investigation or developers' help.