### PR TITLE
Fix http_build_query arg separator to not use &amp;

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -659,14 +659,14 @@ function accredible_course_completed_handler($event) {
 function accredible_update_certificate_grade($certificate_id, $evidence_item_id, $grade) {
 	global $CFG;
 
-  $curl = curl_init(get_api_endpoint() . 'credentials/' . $certificate_id . '/evidence_items/'.$evidence_item_id);
-  curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-  curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
-  curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query( array('evidence_item' => array( 'string_object' => $grade ) ) ));
-  curl_setopt( $curl, CURLOPT_HTTPHEADER, array( 'Authorization: Token token="'.$CFG->accredible_api_key.'"' ) );
+	$curl = curl_init(get_api_endpoint() . 'credentials/' . $certificate_id . '/evidence_items/'.$evidence_item_id);
+	curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
+	curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query(array('evidence_item' => array('string_object' => $grade)), '', '&'));
+	curl_setopt( $curl, CURLOPT_HTTPHEADER, array( 'Authorization: Token token="'.$CFG->accredible_api_key.'"' ) );
 
-  $result = curl_exec($curl);
-  return $result;
+	$result = curl_exec($curl);
+	return $result;
 }
 
 function accredible_get_transcript($course_id, $user_id, $final_quiz_id) {
@@ -715,17 +715,17 @@ function accredible_post_evidence($credential_id, $evidence_item, $allow_excepti
 
 	$curl = curl_init(get_api_endpoint() . 'credentials/' . $credential_id . '/evidence_items');
 	curl_setopt($curl, CURLOPT_POST, true);
-	curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query( array('evidence_item' => $evidence_item) ));
+	curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query(array('evidence_item' => $evidence_item), '', '&'));
 	curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 	curl_setopt($curl, CURLOPT_FAILONERROR, true);
 	curl_setopt( $curl, CURLOPT_HTTPHEADER, array( 'Authorization: Token token="'.$CFG->accredible_api_key.'"' ) );
 	$result = curl_exec($curl);
 	if(!$result && $allow_exceptions) {
-    // throw API exception
-    // include the user id that triggered the error
-    // direct the user to accredible's support
-    // dump the post to debug_info
-    throw new moodle_exception('evidenceadderror', 'accredible', 'https://help.accredible.com/hc/en-us', $credential_id, curl_error($curl));
+		// throw API exception
+		// include the user id that triggered the error
+		// direct the user to accredible's support
+		// dump the post to debug_info
+		throw new moodle_exception('evidenceadderror', 'accredible', 'https://help.accredible.com/hc/en-us', $credential_id, curl_error($curl));
 	}
 	curl_close($curl);
 }


### PR DESCRIPTION
Fix the arg separator of `http_build_query` to use `&` instead of `&amp;` which causes parameter errors in the API server.

The related documentation: https://www.php.net/manual/en/function.http-build-query.php#102324