### PR TITLE
Add PHPUnit to the development Docker Moodle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,6 @@ FROM docker.io/bitnami/moodle:3.11.2
 
 # Install 'vim'
 RUN install_packages vim
+
+# Make a directory for PHPUnit data
+RUN mkdir /bitnami/phpu_moodledata

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Please refer to [Writing PHPUnit tests](https://docs.moodle.org/dev/Writing_PHPU
 
 #### Setup PHPUnit
 
-After the development setup above, log in to the Moodle container.
+After running Moodle with the Accredible plugin, log in to the Moodle container.
 
 ```
 docker exec -it moodle-mod_accredible_moodle_1 bash

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ $CFG->phpunit_dblibrary = 'native';
 $CFG->phpunit_dbhost    = 'mariadb';
 $CFG->phpunit_dbname    = 'test';
 $CFG->phpunit_dbuser    = 'bn_moodle';
-$CFiG->phpunit_dbpass    = '';
+$CFG->phpunit_dbpass    = '';
 ```
 
 Initialise the test environment using the following command.

--- a/README.md
+++ b/README.md
@@ -233,5 +233,6 @@ docker exec -it moodle-mod_accredible_moodle_1 bash
 Run unit tests of this plugin using the following command.
 
 ```
-/bitnami/moodle/vendor/bin/phpunit --testsuite mod_accredible_testsuite
+cd /bitnami/moodle
+vendor/bin/phpunit --testsuite mod_accredible_testsuite
 ```

--- a/README.md
+++ b/README.md
@@ -183,3 +183,55 @@ MOODLE_DATABASE_PASSWORD: (No password)
 ### Environment variables
 
 You can find available environment variables on [README.md](https://github.com/bitnami/bitnami-docker-moodle) of the original docker-compose repository from bitnami.
+
+### Test
+
+This plugin uses [PHPUnit](https://docs.moodle.org/dev/PHPUnit) for the unit tests.
+
+Please refer to [Writing PHPUnit tests](https://docs.moodle.org/dev/Writing_PHPUnit_tests) for more deitals about how to write unit tests.
+
+#### Setup PHPUnit
+
+After the development setup above, log in to the Moodle container.
+
+```
+docker exec -it moodle-mod_accredible_moodle_1 bash
+```
+
+Add the following lines to `config.php`.
+
+```
+vim /bitnami/moodle/config.php
+```
+
+```php
+// PHPUnit
+$CFG->phpunit_prefix = 'phpu_';
+$CFG->phpunit_dataroot = '/bitnami/phpu_moodledata';
+$CFG->phpunit_dbtype    = 'mariadb';
+$CFG->phpunit_dblibrary = 'native';
+$CFG->phpunit_dbhost    = 'mariadb';
+$CFG->phpunit_dbname    = 'test';
+$CFG->phpunit_dbuser    = 'bn_moodle';
+$CFiG->phpunit_dbpass    = '';
+```
+
+Initialise the test environment using the following command.
+
+```
+php /bitnami/moodle/admin/tool/phpunit/cli/init.php
+```
+
+#### Run tests
+
+Log in to the Moodle container.
+
+```
+docker exec -it moodle-mod_accredible_moodle_1 bash
+```
+
+Run unit tests of this plugin using the following command.
+
+```
+/bitnami/moodle/vendor/bin/phpunit --testsuite mod_accredible_testsuite
+```

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -1,0 +1,43 @@
+<?php
+// This file is part of the Accredible Certificate module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for mod/accredible/lib.php
+ *
+ * @package    mod
+ * @subpackage accredible
+ * @copyright  Accredible <dev@accredible.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/mod/accredible/lib.php');
+
+class mod_accredible_lib_testcase extends advanced_testcase {
+    /**
+     * Sample test
+     * later: remove after adding real tests
+     */
+    public function test_sample() {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        // Sample test.
+        $this->assertEmpty("");
+    }
+}

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -1,0 +1,43 @@
+<?php
+// This file is part of the Accredible Certificate module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for mod/accredible/locallib.php
+ *
+ * @package    mod
+ * @subpackage accredible
+ * @copyright  Accredible <dev@accredible.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/mod/accredible/locallib.php');
+
+class mod_accredible_locallib_testcase extends advanced_testcase {
+    /**
+     * Sample test
+     * later: remove after adding real tests
+     */
+    public function test_sample() {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+    
+        // Sample test.
+        $this->assertEmpty("");
+    }
+}


### PR DESCRIPTION
## What changed

Added the PHPUnit setup to the development environment.

## How to test

### Step 1. Rebuild the docker setup

If you've already built the docker environment, please completely shut it down first with the following command.

```
docker-compose down -v
rm -rf .docker/volumes/mariadb/data
```

Remove the old docker image and re-initialize the docker setup.

```
docker rmi moodle-mod_accredible_moodle
docker-compose up
```

After `==> ** Moodle setup finished! **` is displayed, stop the containers and re-run them with the Accredible plugin.

```
docker-compose -f docker-compose.yml -f docker-compose.plugin.yml up -d
```

### Step 2. Setup PHPUnit

Follow the instructions on README [here](https://github.com/accredible/moodle-mod_accredible/blob/e1474e51280e94ab751e838b558e4b7a0488cfe3/README.md#setup-phpunit).

### Step 3. Run tests

Follow the instructions on README [here](https://github.com/accredible/moodle-mod_accredible/blob/e1474e51280e94ab751e838b558e4b7a0488cfe3/README.md#run-tests).

If you run the tests, two dummy tests will pass.