### PR TITLE
Refactor: Move API calls in locallib.php to apiRest.php

### DIFF
--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -21,7 +21,6 @@ use mod_accredible\client\client;
 
 class apiRest {
     private $api_endpoint;
-    private $token;
     private $client;
 
     public function __construct($client = null) {
@@ -37,8 +36,6 @@ class apiRest {
         if($dev_api_endpoint) {
             $this->api_endpoint = $dev_api_endpoint;
         }
-
-        $this->token = $CFG->accredible_api_key;
 
         if($client) {
             $this->client = $client;
@@ -56,7 +53,7 @@ class apiRest {
      * @return stdObject
      */
     function get_credentials($group_id = null, $email = null, $page_size = null, $page = 1) {
-        return $this->client->get("{$this->api_endpoint}all_credentials?group_id={$group_id}&email=" . rawurlencode($email) . "&page_size={$page_size}&page={$page}", $this->token);
+        return $this->client->get("{$this->api_endpoint}all_credentials?group_id={$group_id}&email=" . rawurlencode($email) . "&page_size={$page_size}&page={$page}");
     }
 
     /**
@@ -78,7 +75,7 @@ class apiRest {
 
         $data = json_encode($data);
 
-        return $this->client->post("{$this->api_endpoint}sso/generate_link", $this->token, $data);
+        return $this->client->post("{$this->api_endpoint}sso/generate_link", $data);
     }
 
     /**
@@ -106,7 +103,7 @@ class apiRest {
 
         $data = json_encode($data);
 
-        return $this->client->put("{$this->api_endpoint}issuer/groups/{$id}", $this->token, $data);
+        return $this->client->put("{$this->api_endpoint}issuer/groups/{$id}", $data);
     }
 
     /**
@@ -130,7 +127,7 @@ class apiRest {
 
         $data = json_encode($data);
 
-        return $this->client->post("{$this->api_endpoint}issuer/groups", $this->token, $data);
+        return $this->client->post("{$this->api_endpoint}issuer/groups", $data);
     }
 
     /**
@@ -160,7 +157,7 @@ class apiRest {
 
         $data = json_encode($data);
 
-        return $this->client->post("{$this->api_endpoint}credentials", $this->token, $data);
+        return $this->client->post("{$this->api_endpoint}credentials", $data);
     }
 
     /**
@@ -172,7 +169,7 @@ class apiRest {
 
         $data = json_encode($evidence_item);
 
-        return $this->client->post("{$this->api_endpoint}credentials/{$credential_id}/evidence_items", $this->token, $data);
+        return $this->client->post("{$this->api_endpoint}credentials/{$credential_id}/evidence_items", $data);
     }
 
     /**
@@ -256,7 +253,7 @@ class apiRest {
 
         $data = json_encode($data);
 
-        return $this->client->post("{$this->api_endpoint}credentials", $this->token, $data);
+        return $this->client->post("{$this->api_endpoint}credentials", $data);
     }
 
     /**
@@ -266,7 +263,7 @@ class apiRest {
      * @return stdObject
      */
     function get_groups($page_size = nil, $page = 1) {
-        return $this->client->get($this->api_endpoint.'issuer/all_groups?page_size=' . $page_size . '&page=' . $page, $this->token);
+        return $this->client->get($this->api_endpoint.'issuer/all_groups?page_size=' . $page_size . '&page=' . $page);
     }
 
 

--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -20,7 +20,13 @@ defined('MOODLE_INTERNAL') || die();
 use mod_accredible\client\client;
 
 class apiRest {
-    private $api_endpoint;
+    /**
+     * API base URL.
+     * Use `public` to make unit testing possible.
+     * @var string
+     */
+    public $api_endpoint;
+
     private $client;
 
     public function __construct($client = null) {

--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -24,7 +24,7 @@ class apiRest {
 
     private $token;
 
-    public function __construct($token, $url = null) {
+    public function __construct($token) {
         global $CFG;
 
         $this->api_endpoint = "https://api.accredible.com/v1/";
@@ -33,14 +33,9 @@ class apiRest {
             $this->api_endpoint = "https://eu.api.accredible.com/v1/";
         }
 
-        if(empty($url)) {
-            $this->url = "https://staging.accredible.com/v1/";
-        }
-
         $dev_api_endpoint = getenv("ACCREDIBLE_DEV_API_ENDPOINT");
         if($dev_api_endpoint) {
             $this->api_endpoint = $dev_api_endpoint;
-            $this->url = $dev_api_endpoint;
         }
 
         $this->token = $token;

--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -180,7 +180,7 @@ class apiRest {
         $data = json_encode($evidence_item);
         $result = $this->client->post("{$this->api_endpoint}credentials/{$credential_id}/evidence_items", $data);
         if($throw_error && $this->client->error) {
-            throw new moodle_exception(
+            throw new \moodle_exception(
                 'evidenceadderror', 'accredible', 'https://help.accredible.com/hc/en-us', $credential_id, $this->client->error
             );
         }

--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -22,8 +22,9 @@ use mod_accredible\client\client;
 class apiRest {
     private $api_endpoint;
     private $token;
+    private $client;
 
-    public function __construct() {
+    public function __construct($client = null) {
         global $CFG;
 
         $this->api_endpoint = "https://api.accredible.com/v1/";
@@ -38,6 +39,12 @@ class apiRest {
         }
 
         $this->token = $CFG->accredible_api_key;
+
+        if($client) {
+            $this->client = $client;
+        } else {
+            $this->client = new client();
+        }
     }
 
     /**
@@ -49,7 +56,7 @@ class apiRest {
      * @return stdObject
      */
     function get_credentials($group_id = null, $email = null, $page_size = null, $page = 1) {
-        return client::get("{$this->api_endpoint}all_credentials?group_id={$group_id}&email=" . rawurlencode($email) . "&page_size={$page_size}&page={$page}", $this->token);
+        return $this->client->get("{$this->api_endpoint}all_credentials?group_id={$group_id}&email=" . rawurlencode($email) . "&page_size={$page_size}&page={$page}", $this->token);
     }
 
     /**
@@ -71,7 +78,7 @@ class apiRest {
 
         $data = json_encode($data);
 
-        return client::post("{$this->api_endpoint}sso/generate_link", $this->token, $data);
+        return $this->client->post("{$this->api_endpoint}sso/generate_link", $this->token, $data);
     }
 
     /**
@@ -99,7 +106,7 @@ class apiRest {
 
         $data = json_encode($data);
 
-        return client::put("{$this->api_endpoint}issuer/groups/{$id}", $this->token, $data);
+        return $this->client->put("{$this->api_endpoint}issuer/groups/{$id}", $this->token, $data);
     }
 
     /**
@@ -123,7 +130,7 @@ class apiRest {
 
         $data = json_encode($data);
 
-        return client::post("{$this->api_endpoint}issuer/groups", $this->token, $data);
+        return $this->client->post("{$this->api_endpoint}issuer/groups", $this->token, $data);
     }
 
     /**
@@ -153,7 +160,7 @@ class apiRest {
 
         $data = json_encode($data);
 
-        return client::post("{$this->api_endpoint}credentials", $this->token, $data);
+        return $this->client->post("{$this->api_endpoint}credentials", $this->token, $data);
     }
 
     /**
@@ -165,7 +172,7 @@ class apiRest {
 
         $data = json_encode($evidence_item);
 
-        return client::post("{$this->api_endpoint}credentials/{$credential_id}/evidence_items", $this->token, $data);
+        return $this->client->post("{$this->api_endpoint}credentials/{$credential_id}/evidence_items", $this->token, $data);
     }
 
     /**
@@ -249,7 +256,7 @@ class apiRest {
 
         $data = json_encode($data);
 
-        return client::post("{$this->api_endpoint}credentials", $this->token, $data);
+        return $this->client->post("{$this->api_endpoint}credentials", $this->token, $data);
     }
 
     /**
@@ -259,7 +266,7 @@ class apiRest {
      * @return stdObject
      */
     function get_groups($page_size = nil, $page = 1) {
-        return client::get($this->api_endpoint.'issuer/all_groups?page_size=' . $page_size . '&page=' . $page, $this->token);
+        return $this->client->get($this->api_endpoint.'issuer/all_groups?page_size=' . $page_size . '&page=' . $page, $this->token);
     }
 
 

--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -68,6 +68,15 @@ class apiRest {
     }
 
     /**
+     * Get a Credential with EnvidenceItems
+     * @param Integer $credential_id
+     * @return stdObject
+     */
+    function get_credential($credential_id) {
+        return $this->client->get("{$this->api_endpoint}credentials/{$credential_id}");
+    }
+
+    /**
      * Generaate a Single Sign On Link for a recipient for a particular credential.
      * @return stdObject
      */

--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -304,4 +304,22 @@ class apiRest {
             throw new \InvalidArgumentException("$grade must be a numeric value between 0 and 100.");
         }
     }
+
+    /**
+     * Updates an evidence item on a given credential.
+     * @param Integer $credential_id
+     * @param Integer $evidence_item_id
+     * @param String $grade - value must be between 0 and 100
+     * @return stdObject
+     */
+    function update_evidence_item_grade($credential_id, $evidence_item_id, $grade) {
+        if (is_numeric($grade) && intval($grade) >= 0 && intval($grade) <= 100) {
+            $evidence_item = array('evidence_item' => array('string_object' => $grade));
+            $data = json_encode($evidence_item);
+            $url = "{$this->api_endpoint}credentials/{$credential_id}/evidence_items/{$evidence_item_id}";
+            return $this->client->put($url, $data);
+        } else {
+            throw new \InvalidArgumentException("$grade must be a numeric value between 0 and 100.");
+        }
+    }
 }

--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -165,11 +165,15 @@ class apiRest {
      * @param stdObject $evidence_item
      * @return stdObject
      */
-    function create_evidence_item($evidence_item, $credential_id) {
-
+    function create_evidence_item($evidence_item, $credential_id, $throw_error = false) {
         $data = json_encode($evidence_item);
-
-        return $this->client->post("{$this->api_endpoint}credentials/{$credential_id}/evidence_items", $data);
+        $result = $this->client->post("{$this->api_endpoint}credentials/{$credential_id}/evidence_items", $data);
+        if($throw_error && $this->client->error) {
+            throw new moodle_exception(
+                'evidenceadderror', 'accredible', 'https://help.accredible.com/hc/en-us', $credential_id, $this->client->error
+            );
+        }
+        return $result;
     }
 
     /**

--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -21,10 +21,9 @@ use mod_accredible\client\client;
 
 class apiRest {
     private $api_endpoint;
-
     private $token;
 
-    public function __construct($token) {
+    public function __construct() {
         global $CFG;
 
         $this->api_endpoint = "https://api.accredible.com/v1/";
@@ -38,7 +37,7 @@ class apiRest {
             $this->api_endpoint = $dev_api_endpoint;
         }
 
-        $this->token = $token;
+        $this->token = $CFG->accredible_api_key;
     }
 
     /**

--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -270,21 +270,6 @@ class apiRest {
         return $this->client->get($this->api_endpoint.'issuer/all_groups?page_size=' . $page_size . '&page=' . $page);
     }
 
-
-    /**
-     * Strip out keys with a null value from an object http://stackoverflow.com/a/15953991
-     * @param stdObject $object
-     * @return stdObject
-     */
-    function strip_empty_keys($object) {
-
-        $json = json_encode($object);
-        $json = preg_replace('/,\s*"[^"]+":null|"[^"]+":null,?/', '', $json);
-        $object = json_decode($json);
-
-        return $object;
-    }
-
     /**
      * Creates a Grade evidence item on a given credential.
      * @param String $grade - value must be between 0 and 100
@@ -325,5 +310,19 @@ class apiRest {
         } else {
             throw new \InvalidArgumentException("$grade must be a numeric value between 0 and 100.");
         }
+    }
+
+    /**
+     * Strip out keys with a null value from an object http://stackoverflow.com/a/15953991
+     * @param stdObject $object
+     * @return stdObject
+     */
+    private function strip_empty_keys($object) {
+
+        $json = json_encode($object);
+        $json = preg_replace('/,\s*"[^"]+":null|"[^"]+":null,?/', '', $json);
+        $object = json_decode($json);
+
+        return $object;
     }
 }

--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -27,22 +27,27 @@ class apiRest {
      */
     public $api_endpoint;
 
+    /**
+     * HTTP request client.
+     * @var client
+     */
     private $client;
 
     public function __construct($client = null) {
         global $CFG;
 
-        $this->api_endpoint = "https://api.accredible.com/v1/";
+        $this->api_endpoint = 'https://api.accredible.com/v1/';
 
         if($CFG->is_eu) {
-            $this->api_endpoint = "https://eu.api.accredible.com/v1/";
+            $this->api_endpoint = 'https://eu.api.accredible.com/v1/';
         }
 
-        $dev_api_endpoint = getenv("ACCREDIBLE_DEV_API_ENDPOINT");
+        $dev_api_endpoint = getenv('ACCREDIBLE_DEV_API_ENDPOINT');
         if($dev_api_endpoint) {
             $this->api_endpoint = $dev_api_endpoint;
         }
 
+        // A mock client is passed when unit testing.
         if($client) {
             $this->client = $client;
         } else {

--- a/classes/client/client.php
+++ b/classes/client/client.php
@@ -18,20 +18,19 @@ namespace mod_accredible\client;
 defined('MOODLE_INTERNAL') || die();
 
 class client {
-
-    public static function get($url, $token) {
-        return self::create_req($url, $token, 'GET');
+    function get($url, $token) {
+        return $this->send_req($url, $token, 'GET');
     }
 
-    public static function post($url, $token, $postBody) {
-        return self::create_req($url, $token, 'POST', $postBody);
+    function post($url, $token, $postBody) {
+        return $this->send_req($url, $token, 'POST', $postBody);
     }
 
-    public static function put($url, $token, $putBody) {
-        return self::create_req($url, $token, 'PUT', $putBody);
+    function put($url, $token, $putBody) {
+        return $this->send_req($url, $token, 'PUT', $putBody);
     }
 
-    static function create_req($url, $token, $method, $postBody = null) {
+    private function send_req($url, $token, $method, $postBody = null) {
         global $CFG;
         require_once($CFG->libdir . '/filelib.php');
 

--- a/classes/client/client.php
+++ b/classes/client/client.php
@@ -20,6 +20,8 @@ defined('MOODLE_INTERNAL') || die();
 class client {
     private $curl_options;
 
+    public $error;
+
     public function __construct() {
         global $CFG;
         $token = $CFG->accredible_api_key;
@@ -32,6 +34,8 @@ class client {
                 'Accredible-Integration: Moodle'
             )
         );
+
+        $error = null;
     }
 
     function get($url) {
@@ -70,6 +74,7 @@ class client {
         }
 
         if($curl->error) {
+            $this->error = $curl->error;
             debugging('<div style="padding-top: 70px; font-size: 0.9rem;"><b>ACCREDIBLE API ERROR</b> ' .
                 $curl->error . '<br />' . $method . ' ' . $url . '</div>', DEBUG_DEVELOPER);
         };

--- a/classes/client/client.php
+++ b/classes/client/client.php
@@ -18,33 +18,40 @@ namespace mod_accredible\client;
 defined('MOODLE_INTERNAL') || die();
 
 class client {
-    function get($url, $token) {
-        return $this->send_req($url, $token, 'GET');
-    }
+    private $curl_options;
 
-    function post($url, $token, $postBody) {
-        return $this->send_req($url, $token, 'POST', $postBody);
-    }
-
-    function put($url, $token, $putBody) {
-        return $this->send_req($url, $token, 'PUT', $putBody);
-    }
-
-    private function send_req($url, $token, $method, $postBody = null) {
+    public function __construct() {
         global $CFG;
-        require_once($CFG->libdir . '/filelib.php');
-
-        $curl = new \curl();
-        $options = array(
+        $token = $CFG->accredible_api_key;
+        $this->curl_options = array(
             'CURLOPT_RETURNTRANSFER' => true,
             'CURLOPT_FAILONERROR'    => true,
             'CURLOPT_HTTPHEADER'     => array(
-                'Authorization: Token '.$token,
+                'Authorization: Token ' . $token,
                 'Content-Type: application/json; charset=utf-8',
                 'Accredible-Integration: Moodle'
             )
         );
+    }
 
+    function get($url) {
+        return $this->send_req($url, 'GET');
+    }
+
+    function post($url, $postBody) {
+        return $this->send_req($url, 'POST', $postBody);
+    }
+
+    function put($url, $putBody) {
+        return $this->send_req($url, 'PUT', $putBody);
+    }
+
+    private function send_req($url, $method, $postBody = null) {
+        global $CFG;
+        require_once($CFG->libdir . '/filelib.php');
+
+        $curl = new \curl();
+        $options = $this->curl_options;
         switch($method) {
             case 'GET':
                 $response = $curl->get($url, $postBody, $options);

--- a/locallib.php
+++ b/locallib.php
@@ -453,6 +453,8 @@ function accredible_quiz_submission_handler($event) {
     global $DB, $CFG;
     require_once($CFG->dirroot . '/mod/quiz/lib.php');
 
+    $api = new apiRest();
+
     $attempt = $event->get_record_snapshot('quiz_attempts', $event->objectid);
 
     $quiz = $event->get_record_snapshot('quiz', $attempt->quiz);
@@ -485,7 +487,7 @@ function accredible_quiz_submission_handler($event) {
                                     $highest_grade = min( ( quiz_get_best_grade($quiz, $user->id) / $quiz->grade ) * 100, 100);
                                     $api_grade = intval($evidence_item->string_object->grade);
                                     if ($api_grade < $highest_grade) {
-                                        accredible_update_certificate_grade($existing_certificate->id, $evidence_item->id, $highest_grade);
+                                        $api->update_evidence_item_grade($existing_certificate->id, $evidence_item->id, $highest_grade);
                                     }
                                 }
                             }
@@ -556,7 +558,7 @@ function accredible_quiz_submission_handler($event) {
                                     $highest_grade = min( ( quiz_get_best_grade($quiz, $user->id) / $quiz->grade ) * 100, 100);
                                     $api_grade = intval($evidence_item->string_object->grade);
                                     if ($api_grade < $highest_grade) {
-                                        accredible_update_certificate_grade($existing_certificate->id, $evidence_item->id, $highest_grade);
+                                        $api->update_evidence_item_grade($existing_certificate->id, $evidence_item->id, $highest_grade);
                                     }
                                 }
                             }
@@ -647,12 +649,6 @@ function accredible_course_completed_handler($event) {
             }
         }
     }
-}
-
-function accredible_update_certificate_grade($certificate_id, $evidence_item_id, $grade) {
-    $api = new apiRest();
-    $result = $api->update_evidence_item_grade($certificate_id, $evidence_item_id, $grade);
-    return $result;
 }
 
 function accredible_get_transcript($course_id, $user_id, $final_quiz_id) {

--- a/locallib.php
+++ b/locallib.php
@@ -695,24 +695,9 @@ function accredible_get_transcript($course_id, $user_id, $final_quiz_id) {
     }
 }
 
-function accredible_post_evidence($credential_id, $evidence_item, $allow_exceptions) {
-    global $CFG;
-
-    $curl = curl_init(get_api_endpoint() . 'credentials/' . $credential_id . '/evidence_items');
-    curl_setopt($curl, CURLOPT_POST, true);
-    curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query(array('evidence_item' => $evidence_item), '', '&'));
-    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($curl, CURLOPT_FAILONERROR, true);
-    curl_setopt( $curl, CURLOPT_HTTPHEADER, array( 'Authorization: Token token="'.$CFG->accredible_api_key.'"' ) );
-    $result = curl_exec($curl);
-    if (!$result && $allow_exceptions) {
-        // throw API exception
-        // include the user id that triggered the error
-        // direct the user to accredible's support
-        // dump the post to debug_info
-        throw new moodle_exception('evidenceadderror', 'accredible', 'https://help.accredible.com/hc/en-us', $credential_id, curl_error($curl));
-    }
-    curl_close($curl);
+function accredible_post_evidence($credential_id, $evidence_item, $throw_error = false) {
+    $api = new apiRest();
+    $api->create_evidence_item(array('evidence_item' => $evidence_item), $credential_id, $throw_error);
 }
 
 function accredible_check_for_existing_certificate($achievement_id, $user) {

--- a/locallib.php
+++ b/locallib.php
@@ -482,7 +482,8 @@ function accredible_quiz_submission_handler($event) {
                             }
                         } else {
                             // Check the existing grade to see if this one is higher and update the credential if so.                   
-                            foreach ($existing_certificate->evidence_items as $evidence_item) {
+                            $credential = $api->get_credential($existing_certificate->id)->credential;
+                            foreach ($credential->evidence_items as $evidence_item) {
                                 if ($evidence_item->type == "grade") {
                                     $highest_grade = min( ( quiz_get_best_grade($quiz, $user->id) / $quiz->grade ) * 100, 100);
                                     $api_grade = intval($evidence_item->string_object->grade);
@@ -553,7 +554,8 @@ function accredible_quiz_submission_handler($event) {
                             }
                         } else {
                             // Check the existing grade to see if this one is higher.
-                            foreach ($existing_certificate->evidence_items as $evidence_item) {
+                            $credential = $api->get_credential($existing_certificate->id)->credential;
+                            foreach ($credential->evidence_items as $evidence_item) {
                                 if ($evidence_item->type == "grade") {
                                     $highest_grade = min( ( quiz_get_best_grade($quiz, $user->id) / $quiz->grade ) * 100, 100);
                                     $api_grade = intval($evidence_item->string_object->grade);

--- a/locallib.php
+++ b/locallib.php
@@ -39,7 +39,7 @@ use mod_accredible\Html2Text\Html2Text;
 function sync_course_with_accredible($course, $instance_id = null, $group_id = null) {
     global $DB, $CFG;
 
-    $apiRest = new apiRest($CFG->accredible_api_key);
+    $apiRest = new apiRest();
 
     $description = Html2Text::convert($course->summary);
     if (empty($description)) {
@@ -98,7 +98,7 @@ function accredible_get_credentials($group_id, $email= null) {
     // Maximum number of pages to request to avoid possible infinite loop.
     $loop_limit = 100;
 
-    $apiRest = new apiRest($CFG->accredible_api_key);
+    $apiRest = new apiRest();
 
     try {
 
@@ -145,7 +145,7 @@ function accredible_get_credentials($group_id, $email= null) {
 function accredible_check_for_existing_credential($group_id, $email) {
     global $CFG;
 
-    $apiRest = new apiRest($CFG->accredible_api_key);
+    $apiRest = new apiRest();
     try {
         $credentials = $apiRest->get_credentials($group_id, $email);
 
@@ -244,7 +244,7 @@ function accredible_check_if_cert_earned($record, $course, $user) {
 function create_credential($user, $group_id, $event = null, $issued_on = null) {
     global $CFG;
 
-    $apiRest = new apiRest($CFG->accredible_api_key);
+    $apiRest = new apiRest();
 
     try {
         $credential = $apiRest->create_credential(fullname($user), $user->email, $group_id, $issued_on);
@@ -280,7 +280,7 @@ function create_credential($user, $group_id, $event = null, $issued_on = null) {
 function create_credential_legacy($user, $achievement_name, $course_name, $course_description, $course_link, $issued_on, $event = null){
     global $CFG;
 
-    $apiRest = new apiRest($CFG->accredible_api_key);
+    $apiRest = new apiRest();
 
     try {
         $credential = $apiRest->create_credential_legacy(fullname($user), $user->email, $achievement_name, $issued_on, null, $course_name, $course_description, $course_link);
@@ -312,7 +312,7 @@ function create_credential_legacy($user, $achievement_name, $course_name, $cours
 function accredible_get_groups() {
     global $CFG;
 
-    $apiRest = new apiRest($CFG->accredible_api_key);
+    $apiRest = new apiRest();
     try {
         $response = $apiRest->get_groups(10000, 1);
 
@@ -338,7 +338,7 @@ function accredible_get_groups() {
 function accredible_get_recipient_sso_linik($group_id, $email) {
     global $CFG;
 
-    $apiRest = new apiRest($CFG->accredible_api_key);
+    $apiRest = new apiRest();
 
     try {
         $response = $apiRest->recipient_sso_link(null, null, $email, null, $group_id, null);
@@ -396,7 +396,7 @@ function accredible_issue_default_certificate($user_id, $certificate_id, $name, 
     $course_url = new moodle_url('/course/view.php', array('id' => $accredible_certificate->course));
     $course_link = $course_url->__toString();
 
-    $restApi = new apiRest($CFG->accredible_api_key);
+    $restApi = new apiRest();
     $credential = $restApi->create_credential_legacy($name, $email, $accredible_certificate->achievementid, $issued_on, null, $accredible_certificate->certificatename, $accredible_certificate->description, $course_link);
 
     // Evidence item posts.
@@ -814,7 +814,7 @@ function accredible_course_duration_evidence($user_id, $course_id, $credential_i
     }
 
     if ($enrolment_timestamp && $enrolment_timestamp != 0 && (strtotime($enrolment_timestamp) < strtotime($completed_timestamp))) {
-        $apiRest = new apiRest($CFG->accredible_api_key);
+        $apiRest = new apiRest();
 
         $apiRest->create_evidence_item_duration($enrolment_timestamp, $completed_timestamp, $credential_id, true);
     }

--- a/tests/classes/apiRest/apiRest_test.php
+++ b/tests/classes/apiRest/apiRest_test.php
@@ -88,6 +88,94 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
     }
 
     /**
+     * Tests if `POST /v1/credentials/:credential_id/evidence_items`
+     * is properly called.
+     */
+    public function test_create_evidence_item() {
+        /**
+         * When the throw_error is FALSE and the response is successful.
+         */
+        $mockclient1 = $this->getMockBuilder('client')
+                            ->setMethods(['post'])
+                            ->getMock();
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('evidence_items/create_success.json');
+
+        // Expect to call the endpoint once with url and reqdata
+        $url = 'https://api.accredible.com/v1/credentials/1/evidence_items';
+        $evidence_item = array(
+            'evidence_item' => array(
+                "string_object" => "100",
+                "description" => "Quiz",
+                "custom" => true,
+                "category" => "grade"
+            )
+        );
+        $reqdata = json_encode($evidence_item);
+
+        $mockclient1->expects($this->once())
+                    ->method('post')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata))
+                    ->willReturn($resdata);
+
+        // Expect to return resdata
+        $api = new apiRest($mockclient1);
+        $result = $api->create_evidence_item($evidence_item, 1);
+        $this->assertEquals($result, $resdata);
+
+        /**
+         * When the throw_error is FALSE and the response is NOT successful.
+         */
+        $mockclient2 = $this->getMockBuilder('client')
+                            ->setMethods(['post'])
+                            ->getMock();
+        $mockclient2->error = "The requested URL returned error: 401 Unauthorized";
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('unauthorized_error.json');
+
+        $mockclient2->expects($this->once())
+                    ->method('post')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata))
+                    ->willReturn($resdata);
+
+        // Expect to return resdata without throwing an exception
+        $api = new apiRest($mockclient2);
+        $result = $api->create_evidence_item($evidence_item, 1);
+        $this->assertEquals($result, $resdata);
+
+        /**
+         * When the throw_error is TRUE and the response is NOT successful.
+         */
+        $mockclient3 = $this->getMockBuilder('client')
+                            ->setMethods(['post'])
+                            ->getMock();
+        $mockclient3->error = "The requested URL returned error: 401 Unauthorized";
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('unauthorized_error.json');
+
+        $mockclient3->expects($this->once())
+                    ->method('post')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata))
+                    ->willReturn($resdata);
+
+        // Expect to return resdata without throwing an exception
+        $api = new apiRest($mockclient3);
+        $foundexception = false;
+        try {
+            $api->create_evidence_item($evidence_item, 1, true);
+        } catch (\moodle_exception $error) {
+            $foundexception = true;
+        }
+        $this->assertTrue($foundexception);
+    }
+
+    /**
      * Tests if `PUT /v1/credentials/:credential_id/evidence_items/:id`
      * is properly called.
      */

--- a/tests/classes/apiRest/apiRest_test.php
+++ b/tests/classes/apiRest/apiRest_test.php
@@ -79,6 +79,30 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
     }
 
     /**
+     * Tests if `GET /v1/credentials/:id` is properly called.
+     */
+    public function test_get_credential() {
+        $mockclient = $this->getMockBuilder('client')
+                           ->setMethods(['get'])
+                           ->getMock();
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('credentials/show_success.json');
+
+        // Expect to call the endpoint once with id.
+        $url = 'https://api.accredible.com/v1/credentials/1';
+        $mockclient->expects($this->once())
+                   ->method('get')
+                   ->with($this->equalTo($url))
+                   ->willReturn($resdata);
+
+        // Expect to return resdata.
+        $api = new apiRest($mockclient);
+        $result = $api->get_credential(1);
+        $this->assertEquals($result, $resdata);
+    }
+
+    /**
      * Tests if `POST /v1/credentials/:credential_id/evidence_items`
      * is properly called.
      */

--- a/tests/classes/apiRest/apiRest_test.php
+++ b/tests/classes/apiRest/apiRest_test.php
@@ -31,7 +31,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
     /**
      * Tests that the default endpoint is used when is_eu is NOT enabled.
      */
-    public function test_default_endpoint() {
+    public function test_default_api_endpoint() {
         $this->resetAfterTest();
         $this->setAdminUser();
 
@@ -50,7 +50,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
     /**
      * Tests that the EU endpoint is used when is_eu is enabled.
      */
-    public function test_eu_endpoint() {
+    public function test_eu_api_endpoint() {
         $this->resetAfterTest();
         $this->setAdminUser();
 
@@ -63,6 +63,26 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
         $this->assertEquals($rest->api_endpoint, "https://api.accredible.com/v1/");
 
         // Reset the devlopment environment variable.
+        putenv("ACCREDIBLE_DEV_API_ENDPOINT={$dev_api_endpoint}");
+    }
+
+    /**
+     * Tests that the development endpoint is used when the environemnt variable is set.
+     * Regardless of the is_eu option.
+     */
+    public function test_dev_api_endpoint() {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        // Save the actual devlopment environment variable if it exists.
+        $dev_api_endpoint = getenv("ACCREDIBLE_DEV_API_ENDPOINT");
+        putenv("ACCREDIBLE_DEV_API_ENDPOINT=http://host.docker.internal:3000/v1/");
+
+        set_config("is_eu", "1", "accredible");
+        $rest = new apiRest();
+        $this->assertEquals($rest->api_endpoint, "http://host.docker.internal:3000/v1/");
+
+        // Reset the actual devlopment environment variable.
         putenv("ACCREDIBLE_DEV_API_ENDPOINT={$dev_api_endpoint}");
     }
 }

--- a/tests/classes/apiRest/apiRest_test.php
+++ b/tests/classes/apiRest/apiRest_test.php
@@ -60,29 +60,20 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
     }
 
     /**
-     * Tests that the default endpoint is used when is_eu is NOT enabled.
+     * Tests that the api endpoint changes depending on the config.
      */
-    public function test_default_api_endpoint() {
+    public function test_api_endpoint() {
+        // When is_eu is NOT enabled.
         $api = new apiRest();
         $this->assertEquals($api->api_endpoint, 'https://api.accredible.com/v1/');
-    }
 
-    /**
-     * Tests that the EU endpoint is used when is_eu is enabled.
-     */
-    public function test_eu_api_endpoint() {
+        // When is_eu is enabled.
         set_config('is_eu', 1);
         $api = new apiRest();
         $this->assertEquals($api->api_endpoint, 'https://eu.api.accredible.com/v1/');
-    }
 
-    /**
-     * Tests that the development endpoint is used when the environemnt variable is set.
-     * Regardless of the is_eu option.
-     */
-    public function test_dev_api_endpoint() {
+        // When the environemnt variable is set.
         putenv('ACCREDIBLE_DEV_API_ENDPOINT=http://host.docker.internal:3000/v1/');
-        set_config('is_eu', 1);
         $api = new apiRest();
         $this->assertEquals($api->api_endpoint, 'http://host.docker.internal:3000/v1/');
     }

--- a/tests/classes/apiRest/apiRest_test.php
+++ b/tests/classes/apiRest/apiRest_test.php
@@ -36,7 +36,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
         $this->resetAfterTest();
         $this->setAdminUser();
 
-        // Add plugin settings
+        // Add plugin settings.
         set_config('accredible_api_key', 'sometestapikey');
         set_config('is_eu', 0);
 
@@ -144,7 +144,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
         $mockclient3 = $this->getMockBuilder('client')
                             ->setMethods(['post'])
                             ->getMock();
-        $mockclient3->error = "The requested URL returned error: 401 Unauthorized";
+        $mockclient3->error = 'The requested URL returned error: 401 Unauthorized';
 
         // Mock API response data.
         $resdata = $this->mockapi->resdata('unauthorized_error.json');

--- a/tests/classes/apiRest/apiRest_test.php
+++ b/tests/classes/apiRest/apiRest_test.php
@@ -111,7 +111,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
                            $this->equalTo($reqdata))
                     ->willReturn($resdata);
 
-        // Expect to return resdata
+        // Expect to return resdata.
         $api = new apiRest($mockclient1);
         $result = $api->create_evidence_item($evidence_item, 1);
         $this->assertEquals($result, $resdata);
@@ -133,7 +133,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
                            $this->equalTo($reqdata))
                     ->willReturn($resdata);
 
-        // Expect to return resdata without throwing an exception
+        // Expect to return resdata without throwing an exception.
         $api = new apiRest($mockclient2);
         $result = $api->create_evidence_item($evidence_item, 1);
         $this->assertEquals($result, $resdata);
@@ -155,7 +155,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
                            $this->equalTo($reqdata))
                     ->willReturn($resdata);
 
-        // Expect to return resdata without throwing an exception
+        // Expect to return resdata without throwing an exception.
         $api = new apiRest($mockclient3);
         $foundexception = false;
         try {
@@ -181,7 +181,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
         // Mock API response data.
         $resdata = $this->mockapi->resdata('evidence_items/update_success.json');
 
-        // Expect to call the endpoint once with url and reqdata
+        // Expect to call the endpoint once with url and reqdata.
         $url = 'https://api.accredible.com/v1/credentials/1/evidence_items/1';
         $reqdata = '{"evidence_item":{"string_object":"100"}}';
         $mockclient->expects($this->once())
@@ -190,7 +190,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
                           $this->equalTo($reqdata))
                    ->willReturn($resdata);
         
-        // Expect to return resdata
+        // Expect to return resdata.
         $api = new apiRest($mockclient);
         $result = $api->update_evidence_item_grade(1, 1, '100');
         $this->assertEquals($result, $resdata);

--- a/tests/classes/apiRest/apiRest_test.php
+++ b/tests/classes/apiRest/apiRest_test.php
@@ -82,22 +82,71 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
      * Tests if `GET /v1/credentials/:id` is properly called.
      */
     public function test_get_credential() {
-        $mockclient = $this->getMockBuilder('client')
-                           ->setMethods(['get'])
-                           ->getMock();
+        /**
+         * When the response is successful.
+         */
+        $mockclient1 = $this->getMockBuilder('client')
+                            ->setMethods(['get'])
+                            ->getMock();
 
         // Mock API response data.
         $resdata = $this->mockapi->resdata('credentials/show_success.json');
 
         // Expect to call the endpoint once with id.
         $url = 'https://api.accredible.com/v1/credentials/1';
-        $mockclient->expects($this->once())
-                   ->method('get')
-                   ->with($this->equalTo($url))
-                   ->willReturn($resdata);
+        $mockclient1->expects($this->once())
+                    ->method('get')
+                    ->with($this->equalTo($url))
+                    ->willReturn($resdata);
 
         // Expect to return resdata.
-        $api = new apiRest($mockclient);
+        $api = new apiRest($mockclient1);
+        $result = $api->get_credential(1);
+        $this->assertEquals($result, $resdata);
+
+        /**
+         * When the credential is not found.
+         */
+        $mockclient2 = $this->getMockBuilder('client')
+                            ->setMethods(['get'])
+                            ->getMock();
+        $mockclient2->error = 'The requested URL returned error: 404 Not found';
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('credentials/show_not_found.json');
+
+        // Expect to call the endpoint once with id.
+        $url = 'https://api.accredible.com/v1/credentials/9999';
+        $mockclient2->expects($this->once())
+                    ->method('get')
+                    ->with($this->equalTo($url))
+                    ->willReturn($resdata);
+
+        // Expect to return resdata.
+        $api = new apiRest($mockclient2);
+        $result = $api->get_credential(9999);
+        $this->assertEquals($result, $resdata);
+
+        /**
+         * When the api key is invalid.
+         */
+        $mockclient3 = $this->getMockBuilder('client')
+                            ->setMethods(['get'])
+                            ->getMock();
+        $mockclient3->error = 'The requested URL returned error: 401 Unauthorized';
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('unauthorized_error.json');
+
+        // Expect to call the endpoint once with id.
+        $url = 'https://api.accredible.com/v1/credentials/1';
+        $mockclient3->expects($this->once())
+                    ->method('get')
+                    ->with($this->equalTo($url))
+                    ->willReturn($resdata);
+
+        // Expect to return resdata.
+        $api = new apiRest($mockclient3);
         $result = $api->get_credential(1);
         $this->assertEquals($result, $resdata);
     }
@@ -146,7 +195,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
         $mockclient2 = $this->getMockBuilder('client')
                             ->setMethods(['post'])
                             ->getMock();
-        $mockclient2->error = "The requested URL returned error: 401 Unauthorized";
+        $mockclient2->error = 'The requested URL returned error: 401 Unauthorized';
 
         // Mock API response data.
         $resdata = $this->mockapi->resdata('unauthorized_error.json');
@@ -196,11 +245,11 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
      */
     public function test_update_evidence_item_grade() {
         /**
-         * When the grade is valid number
+         * When the grade is a valid number and the response is successful.
          */
-        $mockclient = $this->getMockBuilder('client')
-                           ->setMethods(['put'])
-                           ->getMock();
+        $mockclient1 = $this->getMockBuilder('client')
+                            ->setMethods(['put'])
+                            ->getMock();
 
         // Mock API response data.
         $resdata = $this->mockapi->resdata('evidence_items/update_success.json');
@@ -208,19 +257,69 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
         // Expect to call the endpoint once with url and reqdata.
         $url = 'https://api.accredible.com/v1/credentials/1/evidence_items/1';
         $reqdata = '{"evidence_item":{"string_object":"100"}}';
-        $mockclient->expects($this->once())
-                   ->method('put')
-                   ->with($this->equalTo($url),
-                          $this->equalTo($reqdata))
-                   ->willReturn($resdata);
-        
+        $mockclient1->expects($this->once())
+                    ->method('put')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata))
+                    ->willReturn($resdata);
+
         // Expect to return resdata.
-        $api = new apiRest($mockclient);
+        $api = new apiRest($mockclient1);
         $result = $api->update_evidence_item_grade(1, 1, '100');
         $this->assertEquals($result, $resdata);
 
         /**
-         * When the grade is NOT number
+         * When the grade is a valid number but the evidence item is not found.
+         */
+        $mockclient2 = $this->getMockBuilder('client')
+                            ->setMethods(['put'])
+                            ->getMock();
+        $mockclient2->error = 'The requested URL returned error: 404 Not found';
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('evidence_items/update_not_found.json');
+
+        // Expect to call the endpoint once with url and reqdata.
+        $url = 'https://api.accredible.com/v1/credentials/1/evidence_items/9999';
+        $reqdata = '{"evidence_item":{"string_object":"100"}}';
+        $mockclient2->expects($this->once())
+                    ->method('put')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata))
+                    ->willReturn($resdata);
+
+        // Expect to return resdata.
+        $api = new apiRest($mockclient2);
+        $result = $api->update_evidence_item_grade(1, 9999, '100');
+        $this->assertEquals($result, $resdata);
+
+        /**
+         * When the grade is a valid number but the api key is invalid.
+         */
+        $mockclient3 = $this->getMockBuilder('client')
+                            ->setMethods(['put'])
+                            ->getMock();
+        $mockclient3->error = 'The requested URL returned error: 401 Unauthorized';
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('unauthorized_error.json');
+
+        // Expect to call the endpoint once with url and reqdata.
+        $url = 'https://api.accredible.com/v1/credentials/1/evidence_items/2';
+        $reqdata = '{"evidence_item":{"string_object":"100"}}';
+        $mockclient3->expects($this->once())
+                    ->method('put')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata))
+                    ->willReturn($resdata);
+
+        // Expect to return resdata.
+        $api = new apiRest($mockclient3);
+        $result = $api->update_evidence_item_grade(1, 2, '100');
+        $this->assertEquals($result, $resdata);
+
+        /**
+         * When the grade is NOT a number.
          */
         $foundexception1 = false;
         try {
@@ -231,7 +330,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
         $this->assertTrue($foundexception1);
 
         /**
-         * When the grade is negative
+         * When the grade is negative.
          */
         $foundexception2 = false;
         try {
@@ -242,7 +341,7 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
         $this->assertTrue($foundexception2);
 
         /**
-         * When the grade is greater than 100
+         * When the grade is greater than 100.
          */
         $foundexception3 = false;
         try {

--- a/tests/classes/apiRest/apiRest_test.php
+++ b/tests/classes/apiRest/apiRest_test.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of the Accredible Certificate module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for mod/accredible/classes/apiRest/apiRest.php
+ *
+ * @package    mod
+ * @subpackage accredible
+ * @copyright  Accredible <dev@accredible.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+use mod_accredible\apiRest\apiRest;
+
+class mod_accredible_apiRest_testcase extends advanced_testcase {
+    /**
+     * Tests that the default endpoint is used when is_eu is NOT enabled.
+     */
+    public function test_default_endpoint() {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        // Unset the devlopment environment variable.
+        $dev_api_endpoint = getenv("ACCREDIBLE_DEV_API_ENDPOINT");
+        putenv('ACCREDIBLE_DEV_API_ENDPOINT');
+
+        set_config("is_eu", "0", "accredible");
+        $rest = new apiRest();
+        $this->assertEquals($rest->api_endpoint, "https://api.accredible.com/v1/");
+
+        // Reset the devlopment environment variable.
+        putenv("ACCREDIBLE_DEV_API_ENDPOINT={$dev_api_endpoint}");
+    }
+
+    /**
+     * Tests that the EU endpoint is used when is_eu is enabled.
+     */
+    public function test_eu_endpoint() {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        // Unset the devlopment environment variable.
+        $dev_api_endpoint = getenv("ACCREDIBLE_DEV_API_ENDPOINT");
+        putenv("ACCREDIBLE_DEV_API_ENDPOINT");
+
+        set_config("is_eu", "1", "accredible");
+        $rest = new apiRest();
+        $this->assertEquals($rest->api_endpoint, "https://api.accredible.com/v1/");
+
+        // Reset the devlopment environment variable.
+        putenv("ACCREDIBLE_DEV_API_ENDPOINT={$dev_api_endpoint}");
+    }
+}

--- a/tests/classes/client/client_test.php
+++ b/tests/classes/client/client_test.php
@@ -65,7 +65,7 @@ class mod_accredible_client_testcase extends advanced_testcase {
                         $this->equalTo(null),
                         $this->equalTo($options));
 
-        // Expect to call curl get
+        // Expect to call curl get.
         $client = new client($mockcurl);
         $client->get($url);
     }
@@ -97,7 +97,7 @@ class mod_accredible_client_testcase extends advanced_testcase {
                         $this->equalTo($reqdata),
                         $this->equalTo($options));
 
-        // Expect to call curl post
+        // Expect to call curl post.
         $client = new client($mockcurl);
         $client->post($url, $reqdata);
     }
@@ -129,7 +129,7 @@ class mod_accredible_client_testcase extends advanced_testcase {
                         $this->equalTo($reqdata),
                         $this->equalTo($options));
 
-        // Expect to call curl put
+        // Expect to call curl put.
         $client = new client($mockcurl);
         $client->put($url, $reqdata);
     }
@@ -162,11 +162,11 @@ class mod_accredible_client_testcase extends advanced_testcase {
 
         $mockcurl->error = 'The requested URL returned error: 401 Unauthorized';
     
-        // Expect to call debugging
+        // Expect to call debugging.
         $client = new client($mockcurl);
         $this->assertDebuggingCalled($client->get($url));
     
-        // Expect to return an error message
+        // Expect to return an error message.
         $this->assertEquals($client->error, 'The requested URL returned error: 401 Unauthorized');
     }
 }

--- a/tests/classes/client/client_test.php
+++ b/tests/classes/client/client_test.php
@@ -1,0 +1,172 @@
+<?php
+// This file is part of the Accredible Certificate module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for mod/accredible/classes/client/client.php
+ *
+ * @package    mod
+ * @subpackage accredible
+ * @copyright  Accredible <dev@accredible.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+use mod_accredible\client\client;
+
+class mod_accredible_client_testcase extends advanced_testcase {
+    /**
+     * Setup before every test.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        // Add plugin settings.
+        set_config('accredible_api_key', 'sometestapikey');
+    }
+
+    /**
+     * Tests whether it calls the curl get function.
+     */
+    public function test_get() {
+        $url = 'https://api.accredible.com/v1/all_credentials';
+        $options = array(
+            'CURLOPT_RETURNTRANSFER' => true,
+            'CURLOPT_FAILONERROR'    => true,
+            'CURLOPT_HTTPHEADER'     => array(
+                'Authorization: Token sometestapikey',
+                'Content-Type: application/json; charset=utf-8',
+                'Accredible-Integration: Moodle'
+            )
+        );
+
+        // Mock curl.
+        $mockcurl = $this->getMockBuilder('curl')
+                         ->setMethods(['get'])
+                         ->getMock();
+
+        $mockcurl->expects($this->once())
+                 ->method('get')
+                 ->with($this->equalTo($url),
+                        $this->equalTo(null),
+                        $this->equalTo($options));
+
+        // Expect to call curl get
+        $client = new client($mockcurl);
+        $client->get($url);
+    }
+
+    /**
+     * Tests whether it calls the curl post function.
+     */
+    public function test_post() {
+        $url = 'https://api.accredible.com/v1/all_credentials';
+        $options = array(
+            'CURLOPT_RETURNTRANSFER' => true,
+            'CURLOPT_FAILONERROR'    => true,
+            'CURLOPT_HTTPHEADER'     => array(
+                'Authorization: Token sometestapikey',
+                'Content-Type: application/json; charset=utf-8',
+                'Accredible-Integration: Moodle'
+            )
+        );
+
+        // Mock curl.
+        $mockcurl = $this->getMockBuilder('curl')
+                         ->setMethods(['post'])
+                         ->getMock();
+
+        $reqdata = '{"evidence_item":{"string_object":"100"}}';
+        $mockcurl->expects($this->once())
+                 ->method('post')
+                 ->with($this->equalTo($url),
+                        $this->equalTo($reqdata),
+                        $this->equalTo($options));
+
+        // Expect to call curl post
+        $client = new client($mockcurl);
+        $client->post($url, $reqdata);
+    }
+
+    /**
+     * Tests whether it calls the curl put function.
+     */
+    public function test_put() {
+        $url = 'https://api.accredible.com/v1/all_credentials';
+        $options = array(
+            'CURLOPT_RETURNTRANSFER' => true,
+            'CURLOPT_FAILONERROR'    => true,
+            'CURLOPT_HTTPHEADER'     => array(
+                'Authorization: Token sometestapikey',
+                'Content-Type: application/json; charset=utf-8',
+                'Accredible-Integration: Moodle'
+            )
+        );
+
+        // Mock curl.
+        $mockcurl = $this->getMockBuilder('curl')
+                         ->setMethods(['put'])
+                         ->getMock();
+
+        $reqdata = '{"evidence_item":{"string_object":"100"}}';
+        $mockcurl->expects($this->once())
+                 ->method('put')
+                 ->with($this->equalTo($url),
+                        $this->equalTo($reqdata),
+                        $this->equalTo($options));
+
+        // Expect to call curl put
+        $client = new client($mockcurl);
+        $client->put($url, $reqdata);
+    }
+
+    /**
+     * Tests whether it returns an error messages when the request fails.
+     */
+    public function test_error() {
+        $url = 'https://api.accredible.com/v1/all_credentials';
+        $options = array(
+            'CURLOPT_RETURNTRANSFER' => true,
+            'CURLOPT_FAILONERROR'    => true,
+            'CURLOPT_HTTPHEADER'     => array(
+                'Authorization: Token sometestapikey',
+                'Content-Type: application/json; charset=utf-8',
+                'Accredible-Integration: Moodle'
+            )
+        );
+
+        // Mock curl.
+        $mockcurl = $this->getMockBuilder('curl')
+                         ->setMethods(['get'])
+                         ->getMock();
+
+        $mockcurl->expects($this->once())
+                 ->method('get')
+                 ->with($this->equalTo($url),
+                        $this->equalTo(null),
+                        $this->equalTo($options));
+
+        $mockcurl->error = 'The requested URL returned error: 401 Unauthorized';
+    
+        // Expect to call debugging
+        $client = new client($mockcurl);
+        $this->assertDebuggingCalled($client->get($url));
+    
+        // Expect to return an error message
+        $this->assertEquals($client->error, 'The requested URL returned error: 401 Unauthorized');
+    }
+}

--- a/tests/fixtures/mockapi/v1/credentials/show_not_found.json
+++ b/tests/fixtures/mockapi/v1/credentials/show_not_found.json
@@ -1,0 +1,4 @@
+{
+    "success": false,
+    "data": "No credential with the id given in your account"
+}

--- a/tests/fixtures/mockapi/v1/credentials/show_success.json
+++ b/tests/fixtures/mockapi/v1/credentials/show_success.json
@@ -1,0 +1,66 @@
+{
+    "credential":{
+      "id":1,
+      "name":"Test course: S",
+      "description":"Test course 1 Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Nulla non arcu lacinia neque faucibus fringilla. Vivamus porttitor turpis ac leo. Integer in sapien. Nullam eget nisl. Aliquam erat volutpat. Cras elementum. Mauris suscipit, ligula sit amet pharetra semper, nibh ante cursus purus, vel sagittis velit mauris vel metus. Integer malesuada. Nullam lectus justo, vulputate eget mollis sed, tempor sed magna. Mauris elementum mauris vitae tortor. Aliquam erat volutpat. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Pellentesque ipsum. Cras pede libero, dapibus nec, pretium sit amet, tempor quis. Aliquam ante. Proin in tellus sit amet nibh dignissim sagittis. Vivamus porttitor turpis ac leo. Duis bibendum, lectus ut viverra rhoncus, dolor nunc faucibus libero, eget facilisis enim ipsum id lacus. In sem justo, commodo ut, suscipit at, pharetra vitae, orci. Aliquam erat volutpat. Nulla est. Vivamus luctus egestas leo. Aenean fermentum risus id tortor. Mauris dictum facilisis augue. Aliquam erat volutpat. Aliquam ornare wisi eu metus. Aliquam id dolor. Duis condimentum augue id magna semper rutrum. Donec iaculis gravida nulla. Pellentesque ipsum. Etiam dictum tincidunt diam. Quisque tincidunt scelerisque libero. Etiam egestas wisi a erat. Integer lacinia. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris tincidunt sem sed arcu. Nullam feugiat, turpis at pulvinar vulputate, erat libero tristique tellus, nec bibendum odio risus sit amet ante. Aliquam id dolor. Maecenas sollicitudin. Et harum quidem rerum facilis est et expedita distinctio. Mauris suscipit, ligula sit amet pharetra semper, nibh ante cursus purus, vel sagittis velit mauris vel metus. Nullam dapibus fermentum ipsum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Pellentesque sapien. Duis risus. Mauris elementum mauris vitae tortor. Suspendisse nisl. Integer rutrum, orci vestibulum ullamcorper ultricies, lacus quam ultricies odio, vitae placerat pede sem sit amet enim. In laoreet, magna id viverra tincidunt, sem odio bibendum justo, vel imperdiet sapien wisi sed libero. Proin pede metus, vulputate nec, fermentum fringilla, vehicula vitae, justo. Nullam justo enim, consectetuer nec, ullamcorper ac, vestibulum in, elit. Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur? Maecenas lorem. Etiam posuere lacus quis dolor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos hymenaeos. Curabitur ligula sapien, pulvinar a vestibulum quis, facilisis vel sapien. Nam sed tellus id magna elementum tincidunt. Suspendisse nisl. Vivamus luctus egestas leo. Nulla non arcu lacinia neque faucibus fringilla. Etiam dui sem, fermentum vitae, sagittis id, malesuada in, quam. Etiam dictum tincidunt diam. Etiam commodo dui eget wisi. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Proin pede metus, vulputate nec, fermentum fringilla, vehicula vitae, justo. Duis ante orci, molestie vitae vehicula venenatis, tincidunt ac pede. Pellentesque sapien.",
+      "approve":false,
+      "grade":null,
+      "complete":true,
+      "issued_on":"2021-09-07",
+      "allow_supplemental_references":null,
+      "allow_supplemental_evidence":null,
+      "course_link":"http:\/\/reynolds.name\/benny",
+      "custom_attributes":{
+
+      },
+      "private":false,
+      "expired_on":null,
+      "group_name":"Test Course378775559",
+      "group_id":1,
+      "url":"http:\/\/localhost:1338b4174243-68a8-4bfa-8479-853aa9208cb8",
+      "encoded_id":"b5oj0m6m",
+      "accredible_internal_id":1,
+      "seo_image":"https:\/\/\/v1\/frontend\/credential_seo_image\/52",
+      "certificate":{
+        "image":{
+          "preview":null
+        }
+      },
+      "badge":{
+        "image":{
+          "preview":null
+        }
+      },
+      "uuid":"b4174243-68a8-4bfa-8479-853aa9208cb8",
+      "recipient":{
+        "name":"Keisuke Inaba",
+        "email":"accredible@example.com",
+        "id":"b4174243-68a8-4bfa-8479-853aa9208cb8",
+        "meta_data":null
+      },
+      "meta_data":null,
+      "evidence_items":[
+        {
+          "id":1,
+          "description":"Quiz",
+          "preview_image_url":null,
+          "link_url":null,
+          "type":"grade",
+          "string_object":{
+            "grade":100
+          },
+          "supplemental":false,
+          "position":1
+        }
+      ],
+      "references":[
+        
+      ],
+      "issuer":{
+        "name":"Accredible",
+        "description":null,
+        "url":"http:\/\/accredible.com",
+        "id":1
+      }
+    }
+  }

--- a/tests/fixtures/mockapi/v1/evidence_items/create_success.json
+++ b/tests/fixtures/mockapi/v1/evidence_items/create_success.json
@@ -1,0 +1,12 @@
+{ 
+    "id": 1,
+    "description": "Quiz",
+    "preview_image_url": null,
+    "link_url": null,
+    "type": "grade",
+    "string_object": {
+        "grade": 100.0
+    },
+    "supplemental": false,
+    "position": 1 
+}

--- a/tests/fixtures/mockapi/v1/evidence_items/update_not_found.json
+++ b/tests/fixtures/mockapi/v1/evidence_items/update_not_found.json
@@ -1,0 +1,3 @@
+{ 
+    "errors": "No Evidence Item with the id given on the credential"
+}

--- a/tests/fixtures/mockapi/v1/evidence_items/update_success.json
+++ b/tests/fixtures/mockapi/v1/evidence_items/update_success.json
@@ -1,0 +1,12 @@
+{ 
+    "id": 1,
+    "description": "Quiz",
+    "preview_image_url": null,
+    "link_url": null,
+    "type": "grade",
+    "string_object": {
+        "grade": 100.0
+    },
+    "supplemental": false,
+    "position": 1 
+}

--- a/tests/fixtures/mockapi/v1/unauthorized_error.json
+++ b/tests/fixtures/mockapi/v1/unauthorized_error.json
@@ -1,0 +1,4 @@
+{
+    "success": false,
+    "data": "issuer_token not valid"
+}


### PR DESCRIPTION
## Description of the change

Updated `accredible_update_certificate_grade()` and `accredible_post_evidence()` in locallib.php to call API with apiRest.php in order for the consistent error logging.

### What changed

#### apiRest.php

- Added a `client` property to the `apiRest` class to make unit testing possible.
- Moved the `token` property (the API key) to the inside of the `client` class.
- Updated `create_evidence_item()` for `accredible_post_evidence()` in locallib.php.
- Added `update_evidence_item_grade()` as a replacement of `accredible_update_certificate_grade()` in locallib.php.
- Added `get_credential()` to fetch `evidence_items` (`GET /v1/all_credentials` does not return `evidence_items`).
- Added unit testing for the changes above.

#### client.php

- Changed all of the `client` class methods to instance methods.
- Added a `curl` property to the `client` class to make unit testing possible.
- Refactored `send_req()`.
- Added unit testing for the changes above.

#### locallib.php

- Updated `accredible_update_certificate_grade()` to call API with apiRest.php.
- Replaced `accredible_post_evidence()` by `update_evidence_item_grade()` in apiRest.php.

### How to test

You can manually test if `accredible_update_certificate_grade()` and `accredible_post_evidence()` work without any errors by the following steps:

#### For accredible_update_certificate_grade()

1. Log in as a student who has completed the final quiz and whose credential has been already issued.
2. Retake the final quiz and get a higher score than before.

#### For accredible_post_evidence()

1. Log in as an admin.
2. Issue a credential for a user who has completed at least one quiz.

#### Unit testing

Also, you can run the unit testing with the PHPUnit command on [README](https://github.com/accredible/moodle-mod_accredible/blob/feature/NTGR-50/locallib-api-call-with-apirest/README.md#test).