### PR TITLE
Update a deprecated API endpoint in accredible_get_templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,9 @@ Run unit tests of this plugin using the following command.
 cd /bitnami/moodle
 vendor/bin/phpunit --testsuite mod_accredible_testsuite
 ```
+
+Run unit tests for a single test class.
+
+```
+vendor/bin/phpunit --filter mod_accredible_xxx_testcase
+```

--- a/classes/apiRest/apiRest.php
+++ b/classes/apiRest/apiRest.php
@@ -291,6 +291,17 @@ class apiRest {
     }
 
     /**
+     * Get all Groups
+     * @param Integer $page_size
+     * @param Integer $page
+     * @return stdObject
+     */
+    function search_groups($page_size = 50, $page = 1) {
+        $data = json_encode(array('page' => $page, 'page_size' => $page_size));
+        return $this->client->post("{$this->api_endpoint}issuer/groups/search", $data);
+    }
+
+    /**
      * Creates a Grade evidence item on a given credential.
      * @param String $grade - value must be between 0 and 100
      * @return stdObject

--- a/locallib.php
+++ b/locallib.php
@@ -374,9 +374,7 @@ function accredible_get_templates($apiRest = null) {
 
     $groups = $response->groups;
     $templates = array();
-    for ($i = 0, $size = count($groups); $i < $size; ++$i) {
-        $templates[$groups[$i]->name] = $groups[$i]->name;
-    }
+    foreach ($groups as $group) { $templates[$group->name] = $group->name; }
     return $templates;
 }
 

--- a/locallib.php
+++ b/locallib.php
@@ -866,19 +866,3 @@ function seconds_to_str ($seconds) {
     }
     return $seconds . ' second' . number_ending($seconds);
 }
-
-function get_api_endpoint() {
-    global $CFG;
-
-    $api_endpoint = "https://api.accredible.com/v1/";
-    if ($CFG->is_eu) {
-        $api_endpoint = "https://eu.api.accredible.com/v1/";
-    }
-
-	$dev_api_endpoint = getenv("ACCREDIBLE_DEV_API_ENDPOINT");
-	if($dev_api_endpoint) {
-		$api_endpoint = $dev_api_endpoint;
-	}
-
-    return $api_endpoint;
-}

--- a/locallib.php
+++ b/locallib.php
@@ -358,22 +358,20 @@ function accredible_get_recipient_sso_linik($group_id, $email) {
  * @return array[stdClass] $templates
  */
 function accredible_get_templates() {
-    global $CFG;
-
-    $curl = curl_init(get_api_endpoint().'issuer/templates');
-    curl_setopt( $curl, CURLOPT_HTTPHEADER, array( 'Authorization: Token token="'.$CFG->accredible_api_key.'"' ) );
-    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-    if (!$result = json_decode( curl_exec($curl) )) {
+    $api = new apiRest();
+    $response = $api->search_groups(10000, 1);
+    $groups = $response->groups;
+    if (!isset($groups)) {
         // Throw API exception.
         // Include the achievement id that triggered the error.
         // Direct the user to accredible's support.
         // Dump the achievement id to debug_info.
         throw new moodle_exception('gettemplateserror', 'accredible', 'https://help.accredible.com/hc/en-us');
     }
-    curl_close($curl);
+
     $templates = array();
-    for ($i = 0, $size = count($result->templates); $i < $size; ++$i) {
-        $templates[$result->templates[$i]->name] = $result->templates[$i]->name;
+    for ($i = 0, $size = count($groups); $i < $size; ++$i) {
+        $templates[$groups[$i]->name] = $groups[$i]->name;
     }
     return $templates;
 }

--- a/locallib.php
+++ b/locallib.php
@@ -355,13 +355,16 @@ function accredible_get_recipient_sso_linik($group_id, $email) {
 /**
  * List all of the issuer's templates
  *
+ * @param apiRest $apiRest
  * @return array[stdClass] $templates
  */
-function accredible_get_templates() {
-    $api = new apiRest();
-    $response = $api->search_groups(10000, 1);
-    $groups = $response->groups;
-    if (!isset($groups)) {
+function accredible_get_templates($apiRest = null) {
+    // An apiRest with a mock client is passed when unit testing.
+    if(!$apiRest) {
+        $apiRest = new apiRest();
+    }
+    $response = $apiRest->search_groups(10000, 1);
+    if (!isset($response->groups)) {
         // Throw API exception.
         // Include the achievement id that triggered the error.
         // Direct the user to accredible's support.
@@ -369,6 +372,7 @@ function accredible_get_templates() {
         throw new moodle_exception('gettemplateserror', 'accredible', 'https://help.accredible.com/hc/en-us');
     }
 
+    $groups = $response->groups;
     $templates = array();
     for ($i = 0, $size = count($groups); $i < $size; ++$i) {
         $templates[$groups[$i]->name] = $groups[$i]->name;

--- a/tests/classes/apiRest/apiRest_test.php
+++ b/tests/classes/apiRest/apiRest_test.php
@@ -79,6 +79,79 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
     }
 
     /**
+     * Tests if `GET /v1/credentials/:id` is properly called.
+     */
+    public function test_get_credential() {
+        /**
+         * When the response is successful.
+         */
+        $mockclient1 = $this->getMockBuilder('client')
+                            ->setMethods(['get'])
+                            ->getMock();
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('credentials/show_success.json');
+
+        // Expect to call the endpoint once with id.
+        $url = 'https://api.accredible.com/v1/credentials/1';
+        $mockclient1->expects($this->once())
+                    ->method('get')
+                    ->with($this->equalTo($url))
+                    ->willReturn($resdata);
+
+        // Expect to return resdata.
+        $api = new apiRest($mockclient1);
+        $result = $api->get_credential(1);
+        $this->assertEquals($result, $resdata);
+
+        /**
+         * When the credential is not found.
+         */
+        $mockclient2 = $this->getMockBuilder('client')
+                            ->setMethods(['get'])
+                            ->getMock();
+        $mockclient2->error = 'The requested URL returned error: 404 Not found';
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('credentials/show_not_found.json');
+
+        // Expect to call the endpoint once with id.
+        $url = 'https://api.accredible.com/v1/credentials/9999';
+        $mockclient2->expects($this->once())
+                    ->method('get')
+                    ->with($this->equalTo($url))
+                    ->willReturn($resdata);
+
+        // Expect to return resdata.
+        $api = new apiRest($mockclient2);
+        $result = $api->get_credential(9999);
+        $this->assertEquals($result, $resdata);
+
+        /**
+         * When the api key is invalid.
+         */
+        $mockclient3 = $this->getMockBuilder('client')
+                            ->setMethods(['get'])
+                            ->getMock();
+        $mockclient3->error = 'The requested URL returned error: 401 Unauthorized';
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('unauthorized_error.json');
+
+        // Expect to call the endpoint once with id.
+        $url = 'https://api.accredible.com/v1/credentials/1';
+        $mockclient3->expects($this->once())
+                    ->method('get')
+                    ->with($this->equalTo($url))
+                    ->willReturn($resdata);
+
+        // Expect to return resdata.
+        $api = new apiRest($mockclient3);
+        $result = $api->get_credential(1);
+        $this->assertEquals($result, $resdata);
+    }
+
+    /**
      * Tests if `POST /v1/issuer/groups/search` is properly called.
      */
     public function test_search_groups() {

--- a/tests/classes/apiRest/apiRest_test.php
+++ b/tests/classes/apiRest/apiRest_test.php
@@ -41,7 +41,6 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
         set_config('is_eu', 0);
 
         // Unset the devlopment environment variable.
-        $dev_api_endpoint = getenv('ACCREDIBLE_DEV_API_ENDPOINT');
         putenv('ACCREDIBLE_DEV_API_ENDPOINT');
 
         $this->mockapi = new class {

--- a/tests/classes/apiRest/apiRest_test.php
+++ b/tests/classes/apiRest/apiRest_test.php
@@ -79,75 +79,83 @@ class mod_accredible_apiRest_testcase extends advanced_testcase {
     }
 
     /**
-     * Tests if `GET /v1/credentials/:id` is properly called.
+     * Tests if `POST /v1/issuer/groups/search` is properly called.
      */
-    public function test_get_credential() {
+    public function test_search_groups() {
         /**
          * When the response is successful.
          */
         $mockclient1 = $this->getMockBuilder('client')
-                            ->setMethods(['get'])
+                            ->setMethods(['post'])
                             ->getMock();
 
         // Mock API response data.
-        $resdata = $this->mockapi->resdata('credentials/show_success.json');
+        $resdata = $this->mockapi->resdata('groups/search_success.json');
 
-        // Expect to call the endpoint once with id.
-        $url = 'https://api.accredible.com/v1/credentials/1';
+        $reqdata = json_encode(array('page' => 1, 'page_size' => 10000));
+
+        // Expect to call the endpoint once with page and page_size.
+        $url = 'https://api.accredible.com/v1/issuer/groups/search';
         $mockclient1->expects($this->once())
-                    ->method('get')
-                    ->with($this->equalTo($url))
+                    ->method('post')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata),)
                     ->willReturn($resdata);
 
         // Expect to return resdata.
         $api = new apiRest($mockclient1);
-        $result = $api->get_credential(1);
+        $result = $api->search_groups(10000, 1);
         $this->assertEquals($result, $resdata);
 
         /**
-         * When the credential is not found.
+         * When the arguments are empty and the response is successful.
          */
         $mockclient2 = $this->getMockBuilder('client')
-                            ->setMethods(['get'])
+                            ->setMethods(['post'])
                             ->getMock();
-        $mockclient2->error = 'The requested URL returned error: 404 Not found';
 
         // Mock API response data.
-        $resdata = $this->mockapi->resdata('credentials/show_not_found.json');
+        $resdata = $this->mockapi->resdata('groups/search_success.json');
 
-        // Expect to call the endpoint once with id.
-        $url = 'https://api.accredible.com/v1/credentials/9999';
+        $reqdata = json_encode(array('page' => 1, 'page_size' => 50));
+
+        // Expect to call the endpoint once with default page and page_size.
+        $url = 'https://api.accredible.com/v1/issuer/groups/search';
         $mockclient2->expects($this->once())
-                    ->method('get')
-                    ->with($this->equalTo($url))
+                    ->method('post')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata),)
                     ->willReturn($resdata);
 
         // Expect to return resdata.
         $api = new apiRest($mockclient2);
-        $result = $api->get_credential(9999);
+        $result = $api->search_groups();
         $this->assertEquals($result, $resdata);
 
         /**
          * When the api key is invalid.
          */
         $mockclient3 = $this->getMockBuilder('client')
-                            ->setMethods(['get'])
+                            ->setMethods(['post'])
                             ->getMock();
         $mockclient3->error = 'The requested URL returned error: 401 Unauthorized';
 
         // Mock API response data.
         $resdata = $this->mockapi->resdata('unauthorized_error.json');
 
-        // Expect to call the endpoint once with id.
-        $url = 'https://api.accredible.com/v1/credentials/1';
+        $reqdata = json_encode(array('page' => 1, 'page_size' => 10000));
+
+        // Expect to call the endpoint once with page and page_size.
+        $url = 'https://api.accredible.com/v1/issuer/groups/search';
         $mockclient3->expects($this->once())
-                    ->method('get')
-                    ->with($this->equalTo($url))
+                    ->method('post')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata),)
                     ->willReturn($resdata);
 
         // Expect to return resdata.
         $api = new apiRest($mockclient3);
-        $result = $api->get_credential(1);
+        $result = $api->search_groups(10000, 1);
         $this->assertEquals($result, $resdata);
     }
 

--- a/tests/fixtures/mockapi/v1/groups/search_success.json
+++ b/tests/fixtures/mockapi/v1/groups/search_success.json
@@ -2,7 +2,7 @@
     "groups": [
       {
         "id": 12472,
-        "name": "new group",
+        "name": "new group1",
         "course_description": "Desscription of course",
         "course_name": "Intro to Programming",
         "learning_outcomes": null,
@@ -23,7 +23,7 @@
       },
       {
         "id": 12473,
-        "name": "new group",
+        "name": "new group2",
         "course_description": "Desscription of course",
         "course_name": "Intro to Programming",
         "learning_outcomes": [

--- a/tests/fixtures/mockapi/v1/groups/search_success.json
+++ b/tests/fixtures/mockapi/v1/groups/search_success.json
@@ -1,0 +1,56 @@
+{
+    "groups": [
+      {
+        "id": 12472,
+        "name": "new group",
+        "course_description": "Desscription of course",
+        "course_name": "Intro to Programming",
+        "learning_outcomes": null,
+        "attach_pdf": true,
+        "course_link": "http://www.example.com",
+        "language": "en",
+        "design_name": "test",
+        "updated_at": "2016-08-29T07:03:25.000Z",
+        "created_at": "2016-08-29T06:14:18.000Z",
+        "design_id": 23,
+        "blockchain": false,
+        "certificate_design_id": 23,
+        "badge_design_id": null,
+        "department_id": 123,
+        "meta_data": {
+          "course_id": "TK764"
+        }
+      },
+      {
+        "id": 12473,
+        "name": "new group",
+        "course_description": "Desscription of course",
+        "course_name": "Intro to Programming",
+        "learning_outcomes": [
+          "skill one",
+          "skill two"
+        ],
+        "attach_pdf": false,
+        "course_link": "http://www.example.com",
+        "language": "en",
+        "design_name": "test",
+        "updated_at": "2016-08-29T07:03:25.000Z",
+        "created_at": "2016-08-29T06:14:18.000Z",
+        "blockchain": true,
+        "design_id": null,
+        "certificate_design_id": null,
+        "badge_design_id": 345,
+        "department_id": 123,
+        "meta_data": {
+          "course_id": "TK765"
+        }
+      }
+    ],
+    "meta": {
+      "current_page": 1,
+      "next_page": 2,
+      "prev_page": null,
+      "total_pages": 119,
+      "total_count": 238
+    }
+  }

--- a/tests/fixtures/mockapi/v1/groups/search_success_empty.json
+++ b/tests/fixtures/mockapi/v1/groups/search_success_empty.json
@@ -1,0 +1,12 @@
+{
+    "groups": [
+
+    ],
+    "meta": {
+      "current_page": 1,
+      "next_page": null,
+      "prev_page": null,
+      "total_pages": 1,
+      "total_count": 0
+    }
+  }

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -43,6 +43,9 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         set_config('accredible_api_key', 'sometestapikey');
         set_config('is_eu', 0);
 
+        // Unset the devlopment environment variable.
+        putenv('ACCREDIBLE_DEV_API_ENDPOINT');
+
         $this->mockapi = new class {
             /**
              * Returns a mock API response based on the fixture json.
@@ -222,7 +225,7 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         $this->assertTrue($foundexception);
 
         /**
-         * When the apiRest returns no groups
+         * When the apiRest returns no groups.
          */
         $mockclient3 = $this->getMockBuilder('client')
                             ->setMethods(['post'])

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -28,16 +28,121 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->dirroot . '/mod/accredible/locallib.php');
 
+use mod_accredible\apiRest\apiRest;
+
 class mod_accredible_locallib_testcase extends advanced_testcase {
     /**
-     * Sample test
-     * later: remove after adding real tests
+     * Setup before every test.
      */
-    public function test_sample() {
+    public function setUp(): void {
         $this->resetAfterTest();
         $this->setAdminUser();
-    
-        // Sample test.
-        $this->assertEmpty("");
+
+        // Add plugin settings.
+        set_config('accredible_api_key', 'sometestapikey');
+        set_config('is_eu', 0);
+
+        $this->mockapi = new class {
+            /**
+             * Returns a mock API response based on the fixture json.
+             * @param string $jsonpath
+             * @return array
+             */
+            public function resdata($jsonpath) {
+                global $CFG;
+                $fixturedir = $CFG->dirroot . '/mod/accredible/tests/fixtures/mockapi/v1/';
+                $filepath = $fixturedir . $jsonpath;
+                return json_decode(file_get_contents($filepath));
+            }
+        };
+    }
+
+    /**
+     * Test whether it returns group name arrays
+     */
+    public function test_accredible_get_templates() {
+        /**
+         * When the apiRest returns groups.
+         */
+        $mockclient1 = $this->getMockBuilder('client')
+                            ->setMethods(['post'])
+                            ->getMock();
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('groups/search_success.json');
+
+        $reqdata = json_encode(array('page' => 1, 'page_size' => 10000));
+
+        // Expect to call the endpoint once with page and page_size.
+        $url = 'https://api.accredible.com/v1/issuer/groups/search';
+        $mockclient1->expects($this->once())
+                    ->method('post')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata),)
+                    ->willReturn($resdata);
+
+        // Expect to return group name arrays.
+        $api = new apiRest($mockclient1);
+        $result = accredible_get_templates($api);
+        $this->assertEquals($result, array(
+            'new group1' => 'new group1',
+            'new group2' => 'new group2',
+        ));
+
+        /**
+         * When the apiRest returns an error response.
+         */
+        $mockclient2 = $this->getMockBuilder('client')
+                            ->setMethods(['post'])
+                            ->getMock();
+
+        // Mock API response data.
+        $mockclient2->error = 'The requested URL returned error: 401 Unauthorized';
+        $resdata = $this->mockapi->resdata('unauthorized_error.json');
+
+        $reqdata = json_encode(array('page' => 1, 'page_size' => 10000));
+
+        // Expect to call the endpoint once with page and page_size.
+        $url = 'https://api.accredible.com/v1/issuer/groups/search';
+        $mockclient2->expects($this->once())
+                    ->method('post')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata),)
+                    ->willReturn($resdata);
+
+        // Expect to raise an exception.
+        $api = new apiRest($mockclient2);
+        $foundexception = false;
+        try {
+            accredible_get_templates($api);
+        } catch (\moodle_exception $error) {
+            $foundexception = true;
+        }
+        $this->assertTrue($foundexception);
+
+        /**
+         * When the apiRest returns no groups
+         */
+        $mockclient3 = $this->getMockBuilder('client')
+                            ->setMethods(['post'])
+                            ->getMock();
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('groups/search_success_empty.json');
+
+        $reqdata = json_encode(array('page' => 1, 'page_size' => 10000));
+
+        // Expect to call the endpoint once with page and page_size.
+        $url = 'https://api.accredible.com/v1/issuer/groups/search';
+        $mockclient3->expects($this->once())
+                    ->method('post')
+                    ->with($this->equalTo($url),
+                           $this->equalTo($reqdata),)
+                    ->willReturn($resdata);
+
+        // Expect to return an empty array.
+        $api = new apiRest($mockclient3);
+        $result = accredible_get_templates($api);
+        $this->assertEquals($result, array());
     }
 }


### PR DESCRIPTION
## Description of the change

The deprecated endpoint `GET /v1/issuer/templates` in `accredible_get_templates()` is replaced with `POST /v1/issuer/groups/search`.

The deprecated one was used to fetch a list of groups and returns an array of group names so it can be replaced with the group search endpoint.

### What changed

- `accredible_get_templates()` is updated with newly created  `apiRest->search_groups()`.
- `get_api_endpoint()` is removed from locallib.php since it's not used anymore.
- Added unit tests for the changes.

### How to test

#### Manual testing

1. Temporarily update the `if` condition at Line114 in `mod_form.php` to return TRUE.
2. Go to the Accredible activity edit page.
3. Check if select options of Group are properly displayed as shown below.

<img width="1431" alt="Screen Shot 2021-09-17 at 13 08 52" src="https://user-images.githubusercontent.com/20009662/133773133-7d07dd69-a393-4a8f-8e63-88e84717725d.png">

#### Unit testing

1. Run the PHPUnit command.