### PR TITLE
fix division by zero bug - add test for accredible_get_transcript

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -680,7 +680,7 @@ function accredible_get_transcript($course_id, $user_id, $final_quiz_id) {
 
     // if they've completed over 2/3 of items
     // and have a passing average, make a transcript
-    if ( $items_completed / max($total_items, 1) >= 0.66 && $total_score / max($items_completed, 1) > 50 ) {
+    if ( $total_items !== 0 && $items_completed !== 0 && $items_completed / $total_items >= 0.66 && $total_score / $items_completed > 50 ) {
         return array(
                 'description' => 'Course Transcript',
                 'string_object' => json_encode($transcript_items),

--- a/locallib.php
+++ b/locallib.php
@@ -680,7 +680,7 @@ function accredible_get_transcript($course_id, $user_id, $final_quiz_id) {
 
     // if they've completed over 2/3 of items
     // and have a passing average, make a transcript
-    if ( $items_completed / $total_items >= 0.66 && $total_score / $items_completed > 50 ) {
+    if ( $items_completed / max($total_items, 1) >= 0.66 && $total_score / max($items_completed, 1) > 50 ) {
         return array(
                 'description' => 'Course Transcript',
                 'string_object' => json_encode($transcript_items),

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -29,15 +29,121 @@ global $CFG;
 require_once($CFG->dirroot . '/mod/accredible/locallib.php');
 
 class mod_accredible_locallib_testcase extends advanced_testcase {
-    /**
-     * Sample test
-     * later: remove after adding real tests
-     */
-    public function test_sample() {
+    function setUp(): void {
         $this->resetAfterTest();
-        $this->setAdminUser();
-    
-        // Sample test.
-        $this->assertEmpty("");
+        global $DB;
+        $this->realDB = $DB;
+
+        $this->user = $this->getDataGenerator()->create_user();
+        $this->course = $this->getDataGenerator()->create_course();
+    }
+
+    public function test_accredible_get_transcript() {
+        global $DB;
+
+        /**
+        * When no quiz available for user.
+        */
+        $DB = $this->createMockDB();
+        $DB->expects($this->once())
+                    ->method("get_records_select")
+                    ->with($this->equalTo("quiz", "course = :course_id", array("course_id" => $this->course->id)))
+                    ->willReturn([]);
+
+        $result = accredible_get_transcript($this->course->id, $this->user->id, 5);
+
+        /**
+        * it responds with false
+        */
+        $this->assertEquals($result, false);
+
+        /**
+         * When user has taken multiple quiz.
+         */
+        $quiz1 = array("id" => 1, "course" => $this->course->id, "name" => "test-quiz1", "grade" => 10, "highest_grade" => 10);
+        $quiz2 = array("id" => 2, "course" => $this->course->id, "name" => "test-quiz2", "grade" => 10, "highest_grade" => 5);
+        $quiz3 = array("id" => 3, "course" => $this->course->id, "name" => "test-quiz3", "grade" => 10, "highest_grade" => 5);
+
+        $quizzes_array = [$quiz1, $quiz2, $quiz3];
+
+        $quizzes = array_map(function($element) {
+            return (object) $element;
+        }, $quizzes_array);
+
+        /**
+        * When user has completed multiple quizzes and has a passing score.
+        */
+        $DB = $this->createMockDB();
+        $DB->expects($this->exactly(3))
+                    ->method("get_field")
+                    ->withConsecutive(array("quiz_grades", "grade",
+                        array("quiz" => $quiz1["id"], "userid" => $this->user->id)),
+                    array("quiz_grades", "grade",
+                        array("quiz" => $quiz2["id"], "userid" => $this->user->id)),
+                    array("quiz_grades", "grade",
+                        array("quiz" => $quiz3["id"], "userid" => $this->user->id)))
+                    ->willReturn($this->onConsecutiveCalls(10, 5, 5));
+
+        $DB->expects($this->once())
+                    ->method("get_records_select")
+                    ->with($this->equalTo("quiz", "course = :course_id", array("course_id" => $this->course->id)))
+                    ->willReturn($quizzes);
+
+        $result = accredible_get_transcript($this->course->id, $this->user->id, 5);
+
+        $transcript_items = array();
+
+        foreach ($quizzes as $quiz) {
+            array_push($transcript_items, array(
+                "category" => $quiz->name,
+                "percent" => min( ( $quiz->highest_grade / $quiz->grade ) * 100, 100 )
+            ));
+        }
+
+        $res_data = array(
+            "description" => "Course Transcript",
+            "string_object" => json_encode($transcript_items),
+            "category" => "transcript",
+            "custom" => true,
+            "hidden" => true
+        );
+
+        /**
+        * it responds with transcript_items
+        */
+        $this->assertEquals($result, $res_data);
+
+        /**
+        * When user has completed multiple quizzes and has a failing score.
+        */
+        $DB = $this->createMockDB();
+        $DB->expects($this->exactly(3))
+                    ->method("get_field")
+                    ->withConsecutive(array("quiz_grades", "grade",
+                        array("quiz" => $quiz1["id"], "userid" => $this->user->id)),
+                    array("quiz_grades", "grade",
+                        array("quiz" => $quiz2["id"], "userid" => $this->user->id)),
+                    array("quiz_grades", "grade",
+                        array("quiz" => $quiz3["id"], "userid" => $this->user->id)))
+                    ->willReturn($this->onConsecutiveCalls(0, 5, 5));
+
+        $DB->expects($this->once())
+                    ->method("get_records_select")
+                    ->with($this->equalTo("quiz", "course = :course_id", array("course_id" => $this->course->id)))
+                    ->willReturn($quizzes);
+
+        $result = accredible_get_transcript($this->course->id, $this->user->id, 5);
+
+        /**
+        * it responds with false
+        */
+        $this->assertEquals($result, false);
+    }
+
+    private function createMockDB()
+    {
+        return $this->getMockBuilder(get_class($this->realDB))
+                    ->setMethods(["get_records_select", "get_field"])
+                    ->getMock();
     }
 }

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -31,9 +31,6 @@ require_once($CFG->dirroot . '/mod/accredible/locallib.php');
 class mod_accredible_locallib_testcase extends advanced_testcase {
     function setUp(): void {
         $this->resetAfterTest();
-        global $DB;
-        $this->realDB = $DB;
-
         $this->user = $this->getDataGenerator()->create_user();
         $this->course = $this->getDataGenerator()->create_course();
     }
@@ -53,7 +50,7 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         $this->assertEquals($result, false);
 
         /**
-         * When user has taken multiple quiz.
+         * When user has taken multiple quizzes.
          */
         $quiz1 = $this->createQuizModule();
         $quiz2 = $this->createQuizModule();
@@ -89,7 +86,7 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         $this->setUp();
 
         /**
-         * When user has taken multiple quiz.
+         * When user has taken multiple quizzes.
          */
         $quiz1 = $this->createQuizModule();
         $quiz2 = $this->createQuizModule();

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -52,16 +52,16 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         /**
          * When user has taken multiple quizzes.
          */
-        $quiz1 = $this->createQuizModule();
-        $quiz2 = $this->createQuizModule();
-        $quiz3 = $this->createQuizModule();
+        $quiz1 = $this->createQuizModule($this->course->id);
+        $quiz2 = $this->createQuizModule($this->course->id);
+        $quiz3 = $this->createQuizModule($this->course->id);
 
         /**
         * When user has completed multiple quizzes and has a passing grade.
         */
-        $this->createQuizGrades($quiz1, 10);
-        $this->createQuizGrades($quiz2, 5);
-        $this->createQuizGrades($quiz3, 5);
+        $this->createQuizGrades($quiz1->id, $this->user->id, 10);
+        $this->createQuizGrades($quiz2->id, $this->user->id, 5);
+        $this->createQuizGrades($quiz3->id, $this->user->id, 5);
 
         $result = accredible_get_transcript($this->course->id, $this->user->id, 0);
 
@@ -88,16 +88,16 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         /**
          * When user has taken multiple quizzes.
          */
-        $quiz1 = $this->createQuizModule();
-        $quiz2 = $this->createQuizModule();
-        $quiz3 = $this->createQuizModule();
+        $quiz1 = $this->createQuizModule($this->course->id);
+        $quiz2 = $this->createQuizModule($this->course->id);
+        $quiz3 = $this->createQuizModule($this->course->id);
 
         /**
         * When user has completed multiple quizzes and has a failing grade.
         */
-        $this->createQuizGrades($quiz1, 0);
-        $this->createQuizGrades($quiz2, 5);
-        $this->createQuizGrades($quiz3, 5);
+        $this->createQuizGrades($quiz1->id, $this->user->id, 0);
+        $this->createQuizGrades($quiz2->id, $this->user->id, 5);
+        $this->createQuizGrades($quiz3->id, $this->user->id, 5);
 
         $result = accredible_get_transcript($this->course->id, $this->user->id, 0);
 
@@ -107,14 +107,14 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         $this->assertEquals($result, false);
     }
 
-    private function createQuizModule() {
-        $quiz = array("course" => $this->course->id, "grade" => 10);
+    private function createQuizModule($course_id) {
+        $quiz = array("course" => $course_id, "grade" => 10);
         return $this->getDataGenerator()->create_module('quiz', $quiz);
     }
 
-    private function createQuizGrades($quiz, $grade) {
+    private function createQuizGrades($quiz_id, $user_id, $grade) {
         global $DB;
-        $quiz_grade = array("quiz" => $quiz->id, "userid" => $this->user->id, "grade" => $grade);
+        $quiz_grade = array("quiz" => $quiz_id, "userid" => $user_id, "grade" => $grade);
         $DB->insert_record('quiz_grades', $quiz_grade);
     }
 }

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -44,61 +44,33 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         /**
         * When no quiz available for user.
         */
-        $DB = $this->createMockDB();
-        $DB->expects($this->once())
-                    ->method("get_records_select")
-                    ->with($this->equalTo("quiz", "course = :course_id", array("course_id" => $this->course->id)))
-                    ->willReturn([]);
-
         $result = accredible_get_transcript($this->course->id, $this->user->id, 5);
 
         /**
         * it responds with false
         */
+        $this->assertEmpty($DB->get_records('quiz'));
         $this->assertEquals($result, false);
 
         /**
          * When user has taken multiple quiz.
          */
-        $quiz1 = array("id" => 1, "course" => $this->course->id, "name" => "test-quiz1", "grade" => 10, "highest_grade" => 10);
-        $quiz2 = array("id" => 2, "course" => $this->course->id, "name" => "test-quiz2", "grade" => 10, "highest_grade" => 5);
-        $quiz3 = array("id" => 3, "course" => $this->course->id, "name" => "test-quiz3", "grade" => 10, "highest_grade" => 5);
-
-        $quizzes_array = [$quiz1, $quiz2, $quiz3];
-
-        $quizzes = array_map(function($element) {
-            return (object) $element;
-        }, $quizzes_array);
+        $quiz1 = $this->createQuizModule();
+        $quiz2 = $this->createQuizModule();
+        $quiz3 = $this->createQuizModule();
 
         /**
-        * When user has completed multiple quizzes and has a passing score.
+        * When user has completed multiple quizzes and has a passing grade.
         */
-        $DB = $this->createMockDB();
-        $DB->expects($this->exactly(3))
-                    ->method("get_field")
-                    ->withConsecutive(array("quiz_grades", "grade",
-                        array("quiz" => $quiz1["id"], "userid" => $this->user->id)),
-                    array("quiz_grades", "grade",
-                        array("quiz" => $quiz2["id"], "userid" => $this->user->id)),
-                    array("quiz_grades", "grade",
-                        array("quiz" => $quiz3["id"], "userid" => $this->user->id)))
-                    ->willReturn($this->onConsecutiveCalls(10, 5, 5));
+        $this->createQuizGrades($quiz1, 10);
+        $this->createQuizGrades($quiz2, 5);
+        $this->createQuizGrades($quiz3, 5);
 
-        $DB->expects($this->once())
-                    ->method("get_records_select")
-                    ->with($this->equalTo("quiz", "course = :course_id", array("course_id" => $this->course->id)))
-                    ->willReturn($quizzes);
+        $result = accredible_get_transcript($this->course->id, $this->user->id, 0);
 
-        $result = accredible_get_transcript($this->course->id, $this->user->id, 5);
-
-        $transcript_items = array();
-
-        foreach ($quizzes as $quiz) {
-            array_push($transcript_items, array(
-                "category" => $quiz->name,
-                "percent" => min( ( $quiz->highest_grade / $quiz->grade ) * 100, 100 )
-            ));
-        }
+        $transcript_items = [["category" => $quiz1->name, "percent" => 100],
+            ["category" => $quiz2->name, "percent" => 50],
+            ["category" => $quiz3->name, "percent" => 50]];
 
         $res_data = array(
             "description" => "Course Transcript",
@@ -113,26 +85,24 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         */
         $this->assertEquals($result, $res_data);
 
+        //reset DB
+        $this->setUp();
+
         /**
-        * When user has completed multiple quizzes and has a failing score.
+         * When user has taken multiple quiz.
+         */
+        $quiz1 = $this->createQuizModule();
+        $quiz2 = $this->createQuizModule();
+        $quiz3 = $this->createQuizModule();
+
+        /**
+        * When user has completed multiple quizzes and has a failing grade.
         */
-        $DB = $this->createMockDB();
-        $DB->expects($this->exactly(3))
-                    ->method("get_field")
-                    ->withConsecutive(array("quiz_grades", "grade",
-                        array("quiz" => $quiz1["id"], "userid" => $this->user->id)),
-                    array("quiz_grades", "grade",
-                        array("quiz" => $quiz2["id"], "userid" => $this->user->id)),
-                    array("quiz_grades", "grade",
-                        array("quiz" => $quiz3["id"], "userid" => $this->user->id)))
-                    ->willReturn($this->onConsecutiveCalls(0, 5, 5));
+        $this->createQuizGrades($quiz1, 0);
+        $this->createQuizGrades($quiz2, 5);
+        $this->createQuizGrades($quiz3, 5);
 
-        $DB->expects($this->once())
-                    ->method("get_records_select")
-                    ->with($this->equalTo("quiz", "course = :course_id", array("course_id" => $this->course->id)))
-                    ->willReturn($quizzes);
-
-        $result = accredible_get_transcript($this->course->id, $this->user->id, 5);
+        $result = accredible_get_transcript($this->course->id, $this->user->id, 0);
 
         /**
         * it responds with false
@@ -140,10 +110,14 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         $this->assertEquals($result, false);
     }
 
-    private function createMockDB()
-    {
-        return $this->getMockBuilder(get_class($this->realDB))
-                    ->setMethods(["get_records_select", "get_field"])
-                    ->getMock();
+    private function createQuizModule() {
+        $quiz = array("course" => $this->course->id, "grade" => 10);
+        return $this->getDataGenerator()->create_module('quiz', $quiz);
+    }
+
+    private function createQuizGrades($quiz, $grade) {
+        global $DB;
+        $quiz_grade = array("quiz" => $quiz->id, "userid" => $this->user->id, "grade" => $grade);
+        $DB->insert_record('quiz_grades', $quiz_grade);
     }
 }

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -41,7 +41,7 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         /**
         * When no quiz available for user.
         */
-        $result = accredible_get_transcript($this->course->id, $this->user->id, 5);
+        $result = accredible_get_transcript($this->course->id, $this->user->id, 0);
 
         /**
         * it responds with false
@@ -50,15 +50,12 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         $this->assertEquals($result, false);
 
         /**
-         * When user has taken multiple quizzes.
-         */
+        * When user has completed multiple quizzes and has a passing grade.
+        */
         $quiz1 = $this->createQuizModule($this->course->id);
         $quiz2 = $this->createQuizModule($this->course->id);
         $quiz3 = $this->createQuizModule($this->course->id);
 
-        /**
-        * When user has completed multiple quizzes and has a passing grade.
-        */
         $this->createQuizGrades($quiz1->id, $this->user->id, 10);
         $this->createQuizGrades($quiz2->id, $this->user->id, 5);
         $this->createQuizGrades($quiz3->id, $this->user->id, 5);
@@ -86,15 +83,45 @@ class mod_accredible_locallib_testcase extends advanced_testcase {
         $this->setUp();
 
         /**
-         * When user has taken multiple quizzes.
-         */
+        * When user has completed multiple quizzes and has a passing grade. The final_quiz_id is one of the valid quizzes and so it will be excluded from the transcripts.
+        */
         $quiz1 = $this->createQuizModule($this->course->id);
         $quiz2 = $this->createQuizModule($this->course->id);
         $quiz3 = $this->createQuizModule($this->course->id);
 
+        $this->createQuizGrades($quiz1->id, $this->user->id, 10);
+        $this->createQuizGrades($quiz2->id, $this->user->id, 5);
+        $this->createQuizGrades($quiz3->id, $this->user->id, 5);
+
+        $result = accredible_get_transcript($this->course->id, $this->user->id, $quiz2->id);
+
+        $transcript_items = [["category" => $quiz1->name, "percent" => 100],
+            ["category" => $quiz3->name, "percent" => 50]];
+
+        $res_data = array(
+            "description" => "Course Transcript",
+            "string_object" => json_encode($transcript_items),
+            "category" => "transcript",
+            "custom" => true,
+            "hidden" => true
+        );
+
+        /**
+        * it responds with transcript_items.
+        * final_quiz_id is excluded from the transcripts returned.
+        */
+        $this->assertEquals($result, $res_data);
+
+        //reset DB
+        $this->setUp();
+
         /**
         * When user has completed multiple quizzes and has a failing grade.
         */
+        $quiz1 = $this->createQuizModule($this->course->id);
+        $quiz2 = $this->createQuizModule($this->course->id);
+        $quiz3 = $this->createQuizModule($this->course->id);
+
         $this->createQuizGrades($quiz1->id, $this->user->id, 0);
         $this->createQuizGrades($quiz2->id, $this->user->id, 5);
         $this->createQuizGrades($quiz3->id, $this->user->id, 5);


### PR DESCRIPTION
### **Description of the change**
This change fixes the division by zero warning on creating a new credential by making sure that the denominator(total_items/items_completed) is never zero.
Tests are added for `accredible_get_transcript` function with scenarios recreating the division by zero issue.

### **How to test**
**Manual testing**
   1. Make sure to enable `development mode` and choose `display debug message` in Site administration > development > debugging
   2. Create a course and enrol users.
   3. Add a quiz to the course with questions.
   4. Add a new accredible activity to a topic in the course and manually issue credential.
   5. Check if the division by zero warning doesn't show up.

**Unit testing**
1. Run the PHPUnit command.
