### PR TITLE
[NTGR-380] lowercase user email address before requesting credentials

### DIFF
--- a/classes/apirest/apirest.php
+++ b/classes/apirest/apirest.php
@@ -77,6 +77,9 @@ class apirest {
      * @return stdObject
      */
     public function get_credentials($groupid = null, $email = null, $pagesize = null, $page = 1) {
+        if ($email) {
+            $email = strtolower($email)
+        }
         return $this->client->get("{$this->apiendpoint}all_credentials?group_id={$groupid}&email=" .
             rawurlencode($email) . "&page_size={$pagesize}&page={$page}");
     }

--- a/classes/apirest/apirest.php
+++ b/classes/apirest/apirest.php
@@ -78,7 +78,7 @@ class apirest {
      */
     public function get_credentials($groupid = null, $email = null, $pagesize = null, $page = 1) {
         if ($email) {
-            $email = strtolower($email)
+            $email = strtolower($email);
         }
         return $this->client->get("{$this->apiendpoint}all_credentials?group_id={$groupid}&email=" .
             rawurlencode($email) . "&page_size={$pagesize}&page={$page}");

--- a/mod_form.php
+++ b/mod_form.php
@@ -187,10 +187,10 @@ class mod_accredible_mod_form extends moodleform_mod {
             $unissuedheader = false;
             foreach ($usersearnedcertificate as $user) {
                 $existingcertificate = false;
-
+                $user_email = strtolower($user->email)
                 foreach ($certificates as $certificate) {
                     // Search through the certificates to see if this user has one existing.
-                    if ($certificate->recipient->email == $user->email) {
+                    if ($certificate->recipient->email == $user_email) {
                         // This user has an existing certificate, no need to continue searching.
                         $existingcertificate = true;
                         break;
@@ -227,9 +227,10 @@ class mod_accredible_mod_form extends moodleform_mod {
 
             foreach ($users as $user) {
                 $certid = null;
+                $user_email = strtolower($user->email)
                 // Check cert emails for this user.
                 foreach ($certificates as $certificate) {
-                    if ($certificate->recipient->email == $user->email) {
+                    if ($certificate->recipient->email == $user_email) {
                         $certid = $certificate->id;
                         if (isset($certificate->url)) {
                             $certlink = $certificate->url;

--- a/mod_form.php
+++ b/mod_form.php
@@ -187,10 +187,9 @@ class mod_accredible_mod_form extends moodleform_mod {
             $unissuedheader = false;
             foreach ($usersearnedcertificate as $user) {
                 $existingcertificate = false;
-                $useremail = strtolower($user->email);
                 foreach ($certificates as $certificate) {
                     // Search through the certificates to see if this user has one existing.
-                    if ($certificate->recipient->email == $useremail) {
+                    if ($certificate->recipient->email == strtolower($user->email)) {
                         // This user has an existing certificate, no need to continue searching.
                         $existingcertificate = true;
                         break;
@@ -227,10 +226,9 @@ class mod_accredible_mod_form extends moodleform_mod {
 
             foreach ($users as $user) {
                 $certid = null;
-                $useremail = strtolower($user->email);
                 // Check cert emails for this user.
                 foreach ($certificates as $certificate) {
-                    if ($certificate->recipient->email == $useremail) {
+                    if ($certificate->recipient->email == strtolower($user->email)) {
                         $certid = $certificate->id;
                         if (isset($certificate->url)) {
                             $certlink = $certificate->url;

--- a/mod_form.php
+++ b/mod_form.php
@@ -187,10 +187,10 @@ class mod_accredible_mod_form extends moodleform_mod {
             $unissuedheader = false;
             foreach ($usersearnedcertificate as $user) {
                 $existingcertificate = false;
-                $user_email = strtolower($user->email)
+                $useremail = strtolower($user->email);
                 foreach ($certificates as $certificate) {
                     // Search through the certificates to see if this user has one existing.
-                    if ($certificate->recipient->email == $user_email) {
+                    if ($certificate->recipient->email == $useremail) {
                         // This user has an existing certificate, no need to continue searching.
                         $existingcertificate = true;
                         break;
@@ -227,10 +227,10 @@ class mod_accredible_mod_form extends moodleform_mod {
 
             foreach ($users as $user) {
                 $certid = null;
-                $user_email = strtolower($user->email)
+                $useremail = strtolower($user->email);
                 // Check cert emails for this user.
                 foreach ($certificates as $certificate) {
-                    if ($certificate->recipient->email == $user_email) {
+                    if ($certificate->recipient->email == $useremail) {
                         $certid = $certificate->id;
                         if (isset($certificate->url)) {
                             $certlink = $certificate->url;

--- a/tests/classes/apirest/apirest_test.php
+++ b/tests/classes/apirest/apirest_test.php
@@ -176,7 +176,7 @@ class mod_accredible_apirest_testcase extends advanced_testcase {
 
         // Expect to return resdata.
         $api = new apirest($mockclient1);
-        $result = $api->get_credentials(9549, "person2@example.com");
+        $result = $api->get_credentials(9549, "PeRSon2@example.com");
         $this->assertEquals($result, $resdata);
 
         // When no credentials are returned from the API.
@@ -219,7 +219,7 @@ class mod_accredible_apirest_testcase extends advanced_testcase {
 
         // Expect to return resdata.
         $api = new apirest($mockclient3);
-        $result = $api->get_credentials(1000, "person2@example.com");
+        $result = $api->get_credentials(1000, "PErson2@example.com");
         $this->assertEquals($result, $resdata);
     }
 

--- a/tests/classes/apirest/apirest_test.php
+++ b/tests/classes/apirest/apirest_test.php
@@ -219,7 +219,7 @@ class mod_accredible_apirest_testcase extends advanced_testcase {
 
         // Expect to return resdata.
         $api = new apirest($mockclient3);
-        $result = $api->get_credentials(1000, "PErson2@example.com");
+        $result = $api->get_credentials(1000, "person2@example.com");
         $this->assertEquals($result, $resdata);
     }
 


### PR DESCRIPTION
Source: [NTGR-380](https://accredible.atlassian.net/browse/NTGR-380)

This commit fix a bug for users that
have an email with capital letters as
we never find a credential for them.

To fix that, we are now sending the email
always in lowercase so we can get the proper
one.