### PR TITLE
Fix for failing unit tests

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,44 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for mod_accredible.
+ *
+ * @package    mod_accredible
+ * @author     Jwalit Shah <jwalitshah@catalyst-au.net>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_accredible\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * The mod_accredible module does not store any data.
+ *
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/accredible.php
+++ b/lang/en/accredible.php
@@ -77,3 +77,5 @@ $string['viewsubheader'] = 'Group ID: {$a}';
 $string['gotodashboard'] = 'To update the appearance of your badges and certificates, visit: <a href="https://dashboard.accredible.com" target="_blank">https://dashboard.accredible.com</a>';
 $string['activitydescription'] = 'This module automatically creates and updates a Credential Group on Accredible. Any certificates and badges issued are in this group and their appearance and information can be updated on <a href="https://dashboard.accredible.com" target="_blank">the dashboard</a>.';
 $string['overview'] = 'Overview';
+
+$string['privacy:metadata'] = "Accredible module does not store any personal data.";

--- a/lang/en/accredible.php
+++ b/lang/en/accredible.php
@@ -52,7 +52,7 @@ $string['id'] = 'ID';
 $string['indexheader'] = 'All certificates/badges for {$a}';
 $string['issued'] = 'Issued';
 $string['manualheader'] = 'Manually issue certificates/badges';
-$string['modulename'] = 'Accredible certificates & badges';
+$string['modulename'] = 'Accredible certificates and badges';
 $string['modulename_help'] = 'The Accredible certificate & badge activity module allows you to issue course certificates or badges to students on accredible.com.
 
 Add the activity wherever you want your students see their certificate or badge.';
@@ -61,7 +61,7 @@ $string['modulenameplural'] = 'Accredible certificates/badges';
 $string['nocertificates'] = 'There are no certificates/badges';
 $string['passinggrade'] = 'Percentage grade needed to pass course (%)';
 $string['pluginadministration'] = 'Accredible certificates/badges administration';
-$string['pluginname'] = 'Accredible certificates & badges';
+$string['pluginname'] = 'Accredible certificates and badges';
 $string['recipient'] = 'Recipient';
 $string['templatename'] = 'Cohort name (from dashboard)';
 $string['groupselect'] = 'Group';


### PR DESCRIPTION
Whilst running unit tests in Moodle 3.9.11+, we came across some failing unit tests.
```
There were 2 failures:

1) tests\core_course\exporters_course_content_item_testcase::test_export_course_content_item
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Accredible certificates &amp; badges'
+'Accredible certificates & badges'

/var/www/prolearn/course/tests/exporters_content_item_test.php:62
/var/www/prolearn/lib/phpunit/classes/advanced_testcase.php:80
phpvfscomposer:///var/www/prolearn/vendor/phpunit/phpunit/phpunit:60

To re-run:
 vendor/bin/phpunit "tests\core_course\exporters_course_content_item_testcase" course/tests/exporters_content_item_test.php

2) provider_testcase::test_all_providers_compliant with data set "mod_accredible" ('mod_accredible', 'mod_accredible\privacy\provider')
Failed asserting that false is true.

/var/www/prolearn/privacy/tests/provider_test.php:178
/var/www/prolearn/lib/phpunit/classes/advanced_testcase.php:80
phpvfscomposer:///var/www/prolearn/vendor/phpunit/phpunit/phpunit:60

To re-run:
 vendor/bin/phpunit "provider_testcase" privacy/tests/provider_test.php
```

Creating a PR here to address these issues. Please kindly review and let us know any feedback