### PR TITLE
NTGR-640: Add privacy API for GDPR

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,105 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Contains class mod_accredible\privacy\provider
+ *
+ * @package    mod_accredible
+ * @subpackage accredible
+ * @copyright  Accredible <dev@accredible.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_accredible\privacy;
+use core_privacy\local\metadata\collection;
+use core_privacy\local\request\approved_contextlist;
+use core_privacy\local\request\approved_userlist;
+use core_privacy\local\request\contextlist;
+use core_privacy\local\request\userlist;
+/**
+ * Ad hoc task that performs the actions for approved data privacy requests.
+ */
+class provider implements
+  \core_privacy\local\metadata\provider,
+  \core_privacy\local\request\plugin\provider,
+  \core_privacy\local\request\core_userlist_provider {
+
+    /**
+     * Returns meta data about this system.
+     *
+     * @param  collection $collection The collection to add metadata to.
+     * @return collection $collection The array of metadata.
+     */
+    public static function get_metadata(collection $collection) : collection {
+
+        $collection->add_external_location_link('accredible', [
+            'email' => 'privacy:metadata:accredible:email',
+            'fullname' => 'privacy:metadata:accredible:fullname',
+        ], 'privacy:metadata:accredible');
+
+        return $collection;
+    }
+
+    /**
+     * Get the list of contexts that contain user information for the specified user.
+     *
+     * @param int $userid The user to search.
+     * @return contextlist $contextlist The list of contexts used in this plugin.
+     */
+    public static function get_contexts_for_userid(int $userid) : contextlist {
+        return new contextlist();
+    }
+
+    /**
+     * Export all user data for the specified user, in the specified contexts, using the supplied exporter instance.
+     *
+     * @param approved_contextlist $contextlist The approved contexts to export information for.
+     */
+    public static function export_user_data(approved_contextlist $contextlist) {
+    }
+
+    /**
+     * Delete all personal data for all users in the specified context.
+     *
+     * @param context $context Context to delete data from.
+     */
+    public static function delete_data_for_all_users_in_context(\context $context) {
+    }
+
+    /**
+     * Delete all user data for the specified user, in the specified contexts.
+     *
+     * @param approved_contextlist $contextlist The approved contexts and user information to delete information for.
+     */
+    public static function delete_data_for_user(approved_contextlist $contextlist) {
+    }
+
+    /**
+     * Get the list of users who have data within a context.
+     *
+     * @param userlist $userlist The userlist containing the list of users who have data in this context/plugin combination.
+     */
+    public static function get_users_in_context(userlist $userlist) {
+    }
+
+    /**
+     * Delete multiple users within a single context.
+     *
+     * @param approved_userlist $userlist The approved context and user information to delete information for.
+     */
+    public static function delete_data_for_users(approved_userlist $userlist) {
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -48,6 +48,7 @@ class provider implements
         $collection->add_external_location_link('accredible', [
             'email' => 'privacy:metadata:accredible:email',
             'fullname' => 'privacy:metadata:accredible:fullname',
+            'quizgrade' => 'privacy:metadata:accredible:quizgrade',
         ], 'privacy:metadata:accredible');
 
         return $collection;

--- a/lang/en/accredible.php
+++ b/lang/en/accredible.php
@@ -78,3 +78,7 @@ $string['gotodashboard'] = 'To update the appearance of your badges and certific
 $string['overview'] = 'Overview';
 $string['activitygroupdescription'] = 'Credentials groups need to have been created in the <a href="{$a}" target="_blank">Accredible Dashboard</a> before credentials can be issued. If none appear, check your API Key to make sure integration is set up correctly.';
 $string['accrediblegroup'] = 'Accredible Group';
+
+$string['privacy:metadata:accredible'] = 'In order to integrate with Accredible, user data needs to be exchanged with that service.';
+$string['privacy:metadata:accredible:email'] = 'Your email address is sent to Accredible to issue a credential.';
+$string['privacy:metadata:accredible:fullname'] = 'Your full name is sent to Accredible to issue a credential.';

--- a/lang/en/accredible.php
+++ b/lang/en/accredible.php
@@ -82,4 +82,4 @@ $string['accrediblegroup'] = 'Accredible Group';
 $string['privacy:metadata:accredible'] = 'In order to integrate with Accredible, user data needs to be exchanged with that service.';
 $string['privacy:metadata:accredible:email'] = 'Your email address is sent to Accredible to issue a credential.';
 $string['privacy:metadata:accredible:fullname'] = 'Your full name is sent to Accredible to issue a credential.';
-$string['privacy:metadata:accredible:quizgrade'] = 'Your quiz grade is sent to Accredible to issue a credential.';
+$string['privacy:metadata:accredible:quizgrade'] = 'Your quiz grade may be sent to Accredible to issue a credential.';

--- a/lang/en/accredible.php
+++ b/lang/en/accredible.php
@@ -82,3 +82,4 @@ $string['accrediblegroup'] = 'Accredible Group';
 $string['privacy:metadata:accredible'] = 'In order to integrate with Accredible, user data needs to be exchanged with that service.';
 $string['privacy:metadata:accredible:email'] = 'Your email address is sent to Accredible to issue a credential.';
 $string['privacy:metadata:accredible:fullname'] = 'Your full name is sent to Accredible to issue a credential.';
+$string['privacy:metadata:accredible:quizgrade'] = 'Your quiz grade is sent to Accredible to issue a credential.';


### PR DESCRIPTION
This PR adds the privacy API which is required for Moodle plugins to allow a Moodle installation to become GDPR compliant.

Documentation: https://docs.moodle.org/dev/Privacy_API

## Requirements

Our plugin does not store any personal data in the Moodle database but sends user's name and email to Accredible to issue credentials. According to "[My plugin only sends data to an external location, but doesn’t store it locally in Moodle - what should I do?](https://docs.moodle.org/dev/Subject_Access_Request_FAQ#My_plugin_only_sends_data_to_an_external_location.2C_but_doesn.E2.80.99t_store_it_locally_in_Moodle_-_what_should_I_do.3F)", our plugin needs to define:

1. `get_metadata` with `add_external_location_link()` to indicate that the plugin sends data to the external system (Accredible).
2. `core_privacy/local/request/plugin/provider` with empty methods including:
    - get_contexts_for_userid
    - export_user_data
    - delete_data_for_all_users_in_context
    - delete_data_for_user
    - get_users_in_context
    - delete_data_for_users

in `classes/privacy/provider.php`.

### Example

Here is an example from one of the existing Moodle plugins (Blackboard Collaborate): https://github.com/open-lms-open-source/moodle-mod_collaborate/blob/master/classes/privacy/provider.php

## Manual Testing

### Before

#### Running the "[Test of privacy API compliance](https://docs.moodle.org/dev/Privacy_API/Utilities)" script

<img width="500" alt="Screen Shot 2022-04-14 at 19 51 08" src="https://user-images.githubusercontent.com/20009662/163520312-3f55a1b1-b9f6-417e-aef5-84be453c8b7b.png">

#### From admin page: `/admin/tool/dataprivacy/pluginregistry.php`

![Screen Shot 2022-04-15 at 13 55 31](https://user-images.githubusercontent.com/20009662/163520786-d6d3b9e3-51ad-4e04-a1f0-09c358a30964.png)


### After

#### Running the "[Test of privacy API compliance](https://docs.moodle.org/dev/Privacy_API/Utilities)" script

<img width="411" alt="Screen Shot 2022-04-14 at 19 51 25" src="https://user-images.githubusercontent.com/20009662/163520378-910f0bc1-86be-4e0b-8d46-78f8149adc1a.png">

#### From admin page: `/admin/tool/dataprivacy/pluginregistry.php`

![Screen Shot 2022-04-15 at 13 21 02](https://user-images.githubusercontent.com/20009662/163520424-c1253c30-323d-4cde-ac09-919e30ba1f82.png)

