### PR TITLE
refactor custom sql queries and create evidenceitems class

### DIFF
--- a/classes/apirest/apirest.php
+++ b/classes/apirest/apirest.php
@@ -238,9 +238,9 @@ class apirest {
     public function create_evidence_item_duration($startdate, $enddate, $credentialid, $hidden = false) {
 
         $durationinfo = array(
-            'start_date' => date("Y-m-d", strtotime($startdate)),
+            'start_date' => date("Y-m-d", $startdate),
             'end_date' => date("Y-m-d", strtotime($enddate)),
-            'duration_in_days' => floor( (strtotime($enddate) - strtotime($startdate)) / 86400)
+            'duration_in_days' => floor( (strtotime($enddate) - $startdate) / 86400)
         );
 
         // Multi day duration.

--- a/classes/apirest/apirest.php
+++ b/classes/apirest/apirest.php
@@ -229,8 +229,8 @@ class apirest {
 
     /**
      * Creates a Grade evidence item on a given credential.
-     * @param string $startdate
-     * @param string $enddate
+     * @param int $startdate
+     * @param int $enddate
      * @param string $credentialid
      * @param bool $hidden
      * @return stdObject
@@ -239,8 +239,8 @@ class apirest {
 
         $durationinfo = array(
             'start_date' => date("Y-m-d", $startdate),
-            'end_date' => date("Y-m-d", strtotime($enddate)),
-            'duration_in_days' => floor( (strtotime($enddate) - $startdate) / 86400)
+            'end_date' => date("Y-m-d", $enddate),
+            'duration_in_days' => floor( ($enddate - $startdate) / 86400)
         );
 
         // Multi day duration.

--- a/classes/local/evidenceitems.php
+++ b/classes/local/evidenceitems.php
@@ -1,0 +1,158 @@
+<?php
+// This file is part of the Accredible Certificate module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_accredible\local;
+
+use mod_accredible\apirest\apirest;
+
+/**
+ * Local functions related to credential evidence items.
+ *
+ * @package    mod_accredible
+ * @subpackage accredible
+ * @copyright  Accredible <dev@accredible.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class evidenceitems {
+    /**
+     * HTTP request apirest.
+     * @var apirest
+     */
+    private $apirest;
+
+    /**
+     * Constructor method
+     *
+     * @param stdObject $apirest a mock apirest for testing.
+     */
+    public function __construct($apirest = null) {
+        // A mock apirest is passed when unit testing.
+        if ($apirest) {
+            $this->apirest = $apirest;
+        } else {
+            $this->apirest = new apirest();
+        }
+    }
+
+    /**
+     * Create evidence item
+     *
+     * @param int $credentialid
+     * @param stdObject $evidenceitem
+     * @param bool $throwerror
+     */
+    public function accredible_post_evidence($credentialid, $evidenceitem, $throwerror = false) {
+        $this->apirest->create_evidence_item(array('evidence_item' => $evidenceitem), $credentialid, $throwerror);
+    }
+
+    /**
+     * Post answers from essay
+     *
+     * @param int $userid
+     * @param int $courseid
+     * @param int $credentialid
+     */
+    public function accredible_post_essay_answers($userid, $courseid, $credentialid) {
+        global $DB, $CFG;
+
+        // Grab the course quizes.
+        if ($quizes = $DB->get_records_select('quiz', 'course = :course_id', array('course_id' => $courseid)) ) {
+            foreach ($quizes as $quiz) {
+                $evidenceitem = array('description' => $quiz->name);
+                // Grab quiz attempts.
+                $quizattempt = $DB->get_records('quiz_attempts', array('quiz' => $quiz->id,
+                    'userid' => $userid), '-attempt', '*', 0, 1);
+
+                if ($quizattempt) {
+                    $sql = "SELECT
+                                    qa.id,
+                                    quiza.quiz,
+                                    quiza.id AS quizattemptid,
+                                    quiza.timestart,
+                                    quiza.timefinish,
+                                    qa.slot,
+                                    qa.behaviour,
+                                    qa.questionsummary AS question,
+                                    qa.responsesummary AS answer
+
+                            FROM {quiz_attempts} quiza
+                            JOIN {question_usages} qu ON qu.id = quiza.uniqueid
+                            JOIN {question_attempts} qa ON qa.questionusageid = qu.id
+
+                            WHERE quiza.id = ? AND qa.behaviour = ?
+
+                            ORDER BY quiza.userid, quiza.attempt, qa.slot";
+
+                    if ( $questions = $DB->get_records_sql($sql, array(reset($quizattempt)->id, 'manualgraded')) ) {
+                        $questionsoutput = "<style>#main {  max-width: 780px;margin-left: auto;";
+                        $questionsoutput .= "margin-right: auto;margin-top: 50px;margin-bottom: 80px; font-family: Arial;} ";
+                        $questionsoutput .= "h1, h5 {   text-align: center;} ";
+                        $questionsoutput .= ".answer { border: 1px solid grey; padding: 20px; font-size: 14px; ";
+                        $questionsoutput .= "line-height: 22px; margin-bottom:30px; margin-top:30px;} ";
+                        $questionsoutput .= "p {font-size: 14px; line-height: 18px;} </style>";
+                        $questionsoutput .= "<div id='main'>";
+                        $questionsoutput .= "<h1>" . $quiz->name . "</h1>";
+                        $questionsoutput .= "<h5>Time Taken: ".
+                            seconds_to_str( current($questions)->timefinish - current($questions)->timestart ) ."</h5>";
+
+                        foreach ($questions as $questionattempt) {
+                            $questionsoutput .= $questionattempt->question;
+                            $questionsoutput .= "<div class='answer'>".$questionattempt->answer."</div>";
+                        }
+
+                        $questionsoutput .= "</div>";
+
+                        $evidenceitem['string_object'] = $questionsoutput;
+                        $evidenceitem['hidden'] = true;
+
+                        // Post the evidence.
+                        $this->accredible_post_evidence($credentialid, $evidenceitem, false);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Create evidence course duration
+     *
+     * @param int $userid
+     * @param int $courseid
+     * @param int $credentialid
+     * @param date|null $completedtimestamp
+     */
+    public function accredible_course_duration_evidence($userid, $courseid, $credentialid, $completedtimestamp = null) {
+        global $DB, $CFG;
+
+        $sql = "SELECT enrol.id, ue.timestart
+                        FROM {enrol} enrol, {user_enrolments} ue
+                        WHERE enrol.id = ue.enrolid AND ue.userid = ? AND enrol.courseid = ?";
+        $enrolment = $DB->get_record_sql($sql, array($userid, $courseid));
+
+        if ($enrolment) {
+            $enrolmenttimestamp = $enrolment->timestart;
+
+            if (!isset($completedtimestamp)) {
+                $completedtimestamp = date("Y-m-d");
+            }
+
+            if ($enrolmenttimestamp && $enrolmenttimestamp != 0 &&
+                (strtotime($enrolmenttimestamp) < strtotime($completedtimestamp))) {
+                $this->apirest->create_evidence_item_duration($enrolmenttimestamp, $completedtimestamp, $credentialid, true);
+            }
+        }
+    }
+}

--- a/classes/local/evidenceitems.php
+++ b/classes/local/evidenceitems.php
@@ -132,7 +132,7 @@ class evidenceitems {
      * @param int $userid
      * @param int $courseid
      * @param int $credentialid
-     * @param date|null $completedtimestamp
+     * @param int|null $completedtimestamp
      */
     public function course_duration_evidence($userid, $courseid, $credentialid, $completedtimestamp = null) {
         global $DB;
@@ -146,11 +146,11 @@ class evidenceitems {
             $enrolmenttimestamp = $enrolment->timestart;
 
             if (!isset($completedtimestamp)) {
-                $completedtimestamp = date("Y-m-d");
+                $completedtimestamp = time();
             }
 
             if ($enrolmenttimestamp && $enrolmenttimestamp != 0 &&
-                ($enrolmenttimestamp < strtotime($completedtimestamp))) {
+                ($enrolmenttimestamp < $completedtimestamp)) {
                 $this->apirest->create_evidence_item_duration($enrolmenttimestamp, $completedtimestamp, $credentialid, true);
             }
         }

--- a/classes/local/evidenceitems.php
+++ b/classes/local/evidenceitems.php
@@ -54,7 +54,7 @@ class evidenceitems {
      * @param stdObject $evidenceitem
      * @param bool $throwerror
      */
-    public function accredible_post_evidence($credentialid, $evidenceitem, $throwerror = false) {
+    public function post_evidence($credentialid, $evidenceitem, $throwerror = false) {
         $this->apirest->create_evidence_item(array('evidence_item' => $evidenceitem), $credentialid, $throwerror);
     }
 
@@ -65,8 +65,8 @@ class evidenceitems {
      * @param int $courseid
      * @param int $credentialid
      */
-    public function accredible_post_essay_answers($userid, $courseid, $credentialid) {
-        global $DB, $CFG;
+    public function post_essay_answers($userid, $courseid, $credentialid) {
+        global $DB;
 
         // Grab the course quizes.
         if ($quizes = $DB->get_records_select('quiz', 'course = :course_id', array('course_id' => $courseid)) ) {
@@ -119,7 +119,7 @@ class evidenceitems {
                         $evidenceitem['hidden'] = true;
 
                         // Post the evidence.
-                        $this->accredible_post_evidence($credentialid, $evidenceitem, false);
+                        $this->post_evidence($credentialid, $evidenceitem, false);
                     }
                 }
             }
@@ -134,8 +134,8 @@ class evidenceitems {
      * @param int $credentialid
      * @param date|null $completedtimestamp
      */
-    public function accredible_course_duration_evidence($userid, $courseid, $credentialid, $completedtimestamp = null) {
-        global $DB, $CFG;
+    public function course_duration_evidence($userid, $courseid, $credentialid, $completedtimestamp = null) {
+        global $DB;
 
         $sql = "SELECT enrol.id, ue.timestart
                         FROM {enrol} enrol, {user_enrolments} ue
@@ -150,7 +150,7 @@ class evidenceitems {
             }
 
             if ($enrolmenttimestamp && $enrolmenttimestamp != 0 &&
-                (strtotime($enrolmenttimestamp) < strtotime($completedtimestamp))) {
+                ($enrolmenttimestamp < strtotime($completedtimestamp))) {
                 $this->apirest->create_evidence_item_duration($enrolmenttimestamp, $completedtimestamp, $credentialid, true);
             }
         }

--- a/lib.php
+++ b/lib.php
@@ -27,6 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot . '/mod/accredible/locallib.php');
 use mod_accredible\local\credentials;
 use mod_accredible\local\groups;
+use mod_accredible\local\evidenceitems;
 
 /**
  * Add certificate instance.

--- a/lib.php
+++ b/lib.php
@@ -69,13 +69,13 @@ function accredible_add_instance($post) {
                     if ($usersgrade < 50) {
                         $gradeevidence['hidden'] = true;
                     }
-                    $evidenceitems->accredible_post_evidence($credentialid, $gradeevidence, true);
+                    $evidenceitems->post_evidence($credentialid, $gradeevidence, true);
                 }
                 if ($transcript = accredible_get_transcript($post->course, $userid, $post->finalquiz)) {
-                    $evidenceitems->accredible_post_evidence($credentialid, $transcript, true);
+                    $evidenceitems->post_evidence($credentialid, $transcript, true);
                 }
-                $evidenceitems->$evidenceitems->accredible_post_essay_answers($userid, $post->course, $credentialid);
-                accredible_course_duration_evidence($userid, $post->course, $credentialid);
+                $evidenceitems->post_essay_answers($userid, $post->course, $credentialid);
+                $evidenceitems->course_duration_evidence($userid, $post->course, $credentialid);
             }
         }
     }
@@ -143,13 +143,13 @@ function accredible_update_instance($post) {
                         if ($usersgrade < 50) {
                             $gradeevidence['hidden'] = true;
                         }
-                        $evidenceitems->accredible_post_evidence($credentialid, $gradeevidence, true);
+                        $evidenceitems->post_evidence($credentialid, $gradeevidence, true);
                     }
                     if ($transcript = accredible_get_transcript($post->course, $userid, $post->finalquiz)) {
-                        $evidenceitems->accredible_post_evidence($credentialid, $transcript, true);
+                        $evidenceitems->post_evidence($credentialid, $transcript, true);
                     }
-                    $evidenceitems->accredible_post_essay_answers($userid, $post->course, $credentialid);
-                    accredible_course_duration_evidence($userid, $post->course, $credentialid, $completedtimestamp);
+                    $evidenceitems->post_essay_answers($userid, $post->course, $credentialid);
+                    $evidenceitems->course_duration_evidence($userid, $post->course, $credentialid, $completedtimestamp);
                 } else if ($accrediblecertificate->achievementid) {
                     if ($post->finalquiz) {
                         $quiz = $DB->get_record('quiz', array('id' => $post->finalquiz), '*', MUST_EXIST);
@@ -203,13 +203,13 @@ function accredible_update_instance($post) {
                     if ($usersgrade < 50) {
                         $gradeevidence['hidden'] = true;
                     }
-                    $evidenceitems->accredible_post_evidence($credentialid, $gradeevidence, true);
+                    $evidenceitems->post_evidence($credentialid, $gradeevidence, true);
                 }
                 if ($transcript = accredible_get_transcript($post->course, $userid, $post->finalquiz)) {
-                    $evidenceitems->accredible_post_evidence($credentialid, $transcript, true);
+                    $evidenceitems->post_evidence($credentialid, $transcript, true);
                 }
-                $evidenceitems->accredible_post_essay_answers($userid, $post->course, $credentialid);
-                accredible_course_duration_evidence($userid, $post->course, $credentialid, $completedtimestamp);
+                $evidenceitems->post_essay_answers($userid, $post->course, $credentialid);
+                $evidenceitems->course_duration_evidence($userid, $post->course, $credentialid, $completedtimestamp);
 
                 // Log the creation.
                 $event = accredible_log_creation(

--- a/lib.php
+++ b/lib.php
@@ -47,6 +47,7 @@ function accredible_add_instance($post) {
     $groupid = $localgroups->sync_group_with($course, $post->instance, $post->groupid);
 
     $localcredentials = new credentials();
+    $evidenceitems = new evidenceitems();
 
     // Issue certs.
     if ( isset($post->users) ) {
@@ -68,12 +69,12 @@ function accredible_add_instance($post) {
                     if ($usersgrade < 50) {
                         $gradeevidence['hidden'] = true;
                     }
-                    accredible_post_evidence($credentialid, $gradeevidence, true);
+                    $evidenceitems->accredible_post_evidence($credentialid, $gradeevidence, true);
                 }
                 if ($transcript = accredible_get_transcript($post->course, $userid, $post->finalquiz)) {
-                    accredible_post_evidence($credentialid, $transcript, true);
+                    $evidenceitems->accredible_post_evidence($credentialid, $transcript, true);
                 }
-                accredible_post_essay_answers($userid, $post->course, $credentialid);
+                $evidenceitems->$evidenceitems->accredible_post_essay_answers($userid, $post->course, $credentialid);
                 accredible_course_duration_evidence($userid, $post->course, $credentialid);
             }
         }
@@ -103,6 +104,7 @@ function accredible_update_instance($post) {
     global $DB;
 
     $localcredentials = new credentials();
+    $evidenceitems = new evidenceitems();
 
     $accrediblecertificate = $DB->get_record('accredible', array('id' => $post->instance), '*', MUST_EXIST);
 
@@ -141,12 +143,12 @@ function accredible_update_instance($post) {
                         if ($usersgrade < 50) {
                             $gradeevidence['hidden'] = true;
                         }
-                        accredible_post_evidence($credentialid, $gradeevidence, true);
+                        $evidenceitems->accredible_post_evidence($credentialid, $gradeevidence, true);
                     }
                     if ($transcript = accredible_get_transcript($post->course, $userid, $post->finalquiz)) {
-                        accredible_post_evidence($credentialid, $transcript, true);
+                        $evidenceitems->accredible_post_evidence($credentialid, $transcript, true);
                     }
-                    accredible_post_essay_answers($userid, $post->course, $credentialid);
+                    $evidenceitems->accredible_post_essay_answers($userid, $post->course, $credentialid);
                     accredible_course_duration_evidence($userid, $post->course, $credentialid, $completedtimestamp);
                 } else if ($accrediblecertificate->achievementid) {
                     if ($post->finalquiz) {
@@ -201,12 +203,12 @@ function accredible_update_instance($post) {
                     if ($usersgrade < 50) {
                         $gradeevidence['hidden'] = true;
                     }
-                    accredible_post_evidence($credentialid, $gradeevidence, true);
+                    $evidenceitems->accredible_post_evidence($credentialid, $gradeevidence, true);
                 }
                 if ($transcript = accredible_get_transcript($post->course, $userid, $post->finalquiz)) {
-                    accredible_post_evidence($credentialid, $transcript, true);
+                    $evidenceitems->accredible_post_evidence($credentialid, $transcript, true);
                 }
-                accredible_post_essay_answers($userid, $post->course, $credentialid);
+                $evidenceitems->accredible_post_essay_answers($userid, $post->course, $credentialid);
                 accredible_course_duration_evidence($userid, $post->course, $credentialid, $completedtimestamp);
 
                 // Log the creation.

--- a/locallib.php
+++ b/locallib.php
@@ -26,6 +26,7 @@
 use mod_accredible\apirest\apirest;
 use mod_accredible\Html2Text\Html2Text;
 use mod_accredible\local\credentials;
+use mod_accredible\local\evidenceitems;
 
 /**
  * Checks if a user has earned a specific credential according to the activity settings

--- a/locallib.php
+++ b/locallib.php
@@ -163,12 +163,14 @@ function accredible_issue_default_certificate($userid, $certificateid, $name, $e
         $response = $restapi->create_evidence_item_grade($grade, $quizname, $credentialid, $hidden);
     }
 
+    $evidenceitem = new evidenceitem();
+
     if ($transcript = accredible_get_transcript($accrediblecertificate->course, $userid, $accrediblecertificate->finalquiz)) {
-        accredible_post_evidence($credentialid, $transcript, false);
+        $evidenceitem->accredible_post_evidence($credentialid, $transcript, false);
     }
 
-    accredible_post_essay_answers($userid, $accrediblecertificate->course, $credentialid);
-    accredible_course_duration_evidence($userid, $accrediblecertificate->course, $credentialid, $completedtimestamp);
+    $evidenceitem->accredible_post_essay_answers($userid, $accrediblecertificate->course, $credentialid);
+    $evidenceitem->accredible_course_duration_evidence($userid, $accrediblecertificate->course, $credentialid, $completedtimestamp);
 
     return json_decode($result);
 }
@@ -468,18 +470,6 @@ function accredible_get_transcript($courseid, $userid, $finalquizid) {
 }
 
 /**
- * Create evidence item
- *
- * @param int $credentialid
- * @param stdObject $evidenceitem
- * @param bool $throwerror
- */
-function accredible_post_evidence($credentialid, $evidenceitem, $throwerror = false) {
-    $api = new apirest();
-    $api->create_evidence_item(array('evidence_item' => $evidenceitem), $credentialid, $throwerror);
-}
-
-/**
  * Serialize completion array
  *
  * @param Array $completionarray
@@ -495,102 +485,6 @@ function serialize_completion_array($completionarray) {
  */
 function unserialize_completion_array($completionobject) {
     return (array)unserialize(base64_decode( $completionobject ));
-}
-
-/**
- * Post answers from essay
- *
- * @param int $userid
- * @param int $courseid
- * @param int $credentialid
- */
-function accredible_post_essay_answers($userid, $courseid, $credentialid) {
-    global $DB, $CFG;
-
-    // Grab the course quizes.
-    if ($quizes = $DB->get_records_select('quiz', 'course = :course_id', array('course_id' => $courseid)) ) {
-        foreach ($quizes as $quiz) {
-            $evidenceitem = array('description' => $quiz->name);
-            // Grab quiz attempts.
-            $quizattempt = $DB->get_records('quiz_attempts', array('quiz' => $quiz->id,
-                'userid' => $userid), '-attempt', '*', 0, 1);
-
-            if ($quizattempt) {
-                $sql = "SELECT
-                        qa.id,
-                        quiza.quiz,
-                        quiza.id AS quizattemptid,
-                        quiza.timestart,
-                        quiza.timefinish,
-                        qa.slot,
-                        qa.behaviour,
-                        qa.questionsummary AS question,
-                        qa.responsesummary AS answer
-
-                FROM ".$CFG->prefix."quiz_attempts quiza
-                JOIN ".$CFG->prefix."question_usages qu ON qu.id = quiza.uniqueid
-                JOIN ".$CFG->prefix."question_attempts qa ON qa.questionusageid = qu.id
-
-                WHERE quiza.id = ? && qa.behaviour = 'manualgraded'
-
-                ORDER BY quiza.userid, quiza.attempt, qa.slot";
-
-                if ( $questions = $DB->get_records_sql($sql, array(reset($quizattempt)->id)) ) {
-                    $questionsoutput = "<style>#main {  max-width: 780px;margin-left: auto;";
-                    $questionsoutput .= "margin-right: auto;margin-top: 50px;margin-bottom: 80px; font-family: Arial;} ";
-                    $questionsoutput .= "h1, h5 {   text-align: center;} ";
-                    $questionsoutput .= ".answer { border: 1px solid grey; padding: 20px; font-size: 14px; ";
-                    $questionsoutput .= "line-height: 22px; margin-bottom:30px; margin-top:30px;} ";
-                    $questionsoutput .= "p {font-size: 14px; line-height: 18px;} </style>";
-                    $questionsoutput .= "<div id='main'>";
-                    $questionsoutput .= "<h1>" . $quiz->name . "</h1>";
-                    $questionsoutput .= "<h5>Time Taken: ".
-                        seconds_to_str( current($questions)->timefinish - current($questions)->timestart ) ."</h5>";
-
-                    foreach ($questions as $questionattempt) {
-                        $questionsoutput .= $questionattempt->question;
-                        $questionsoutput .= "<div class='answer'>".$questionattempt->answer."</div>";
-                    }
-
-                    $questionsoutput .= "</div>";
-
-                    $evidenceitem['string_object'] = $questionsoutput;
-                    $evidenceitem['hidden'] = true;
-
-                    // Post the evidence.
-                    accredible_post_evidence($credentialid, $evidenceitem, false);
-                }
-            }
-        }
-    }
-}
-
-/**
- * Create evidence course duration
- *
- * @param int $userid
- * @param int $courseid
- * @param int $credentialid
- * @param date|null $completedtimestamp
- */
-function accredible_course_duration_evidence($userid, $courseid, $credentialid, $completedtimestamp = null) {
-    global $DB, $CFG;
-
-    $sql = "SELECT enrol.id, ue.timestart
-                    FROM ".$CFG->prefix."enrol enrol, ".$CFG->prefix."user_enrolments ue
-                    WHERE enrol.id = ue.enrolid AND ue.userid = ? AND enrol.courseid = ?";
-    $enrolment = $DB->get_record_sql($sql, array($userid, $courseid));
-    $enrolmenttimestamp = $enrolment->timestart;
-
-    if (!isset($completedtimestamp)) {
-        $completedtimestamp = date("Y-m-d");
-    }
-
-    if ($enrolmenttimestamp && $enrolmenttimestamp != 0 && (strtotime($enrolmenttimestamp) < strtotime($completedtimestamp))) {
-        $apirest = new apirest();
-
-        $apirest->create_evidence_item_duration($enrolmenttimestamp, $completedtimestamp, $credentialid, true);
-    }
 }
 
 /**

--- a/locallib.php
+++ b/locallib.php
@@ -166,11 +166,11 @@ function accredible_issue_default_certificate($userid, $certificateid, $name, $e
     $evidenceitem = new evidenceitem();
 
     if ($transcript = accredible_get_transcript($accrediblecertificate->course, $userid, $accrediblecertificate->finalquiz)) {
-        $evidenceitem->accredible_post_evidence($credentialid, $transcript, false);
+        $evidenceitem->post_evidence($credentialid, $transcript, false);
     }
 
-    $evidenceitem->accredible_post_essay_answers($userid, $accrediblecertificate->course, $credentialid);
-    $evidenceitem->accredible_course_duration_evidence($userid, $accrediblecertificate->course, $credentialid, $completedtimestamp);
+    $evidenceitem->post_essay_answers($userid, $accrediblecertificate->course, $credentialid);
+    $evidenceitem->course_duration_evidence($userid, $accrediblecertificate->course, $credentialid, $completedtimestamp);
 
     return json_decode($result);
 }

--- a/tests/local/mod_accredible_evidenceitems_test.php
+++ b/tests/local/mod_accredible_evidenceitems_test.php
@@ -1,0 +1,367 @@
+<?php
+// This file is part of the Accredible Certificate module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_accredible\local;
+
+use mod_accredible\apirest\apirest;
+
+/**
+ * Unit tests for mod/accredible/classes/local/credentials.php
+ *
+ * @package    mod_accredible
+ * @subpackage accredible
+ * @category   test
+ * @copyright  Accredible <dev@accredible.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_accredible_evidenceitems_test extends \advanced_testcase {
+    /**
+     * Setup before every test.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+
+        // Add plugin settings.
+        set_config('accredible_api_key', 'sometestapikey');
+        set_config('is_eu', 0);
+
+        // Unset the devlopment environment variable.
+        putenv('ACCREDIBLE_DEV_API_ENDPOINT');
+
+        $this->mockapi = new class {
+            /**
+             * Returns a mock API response based on the fixture json.
+             * @param string $jsonpath
+             * @return array
+             */
+            public function resdata($jsonpath) {
+                global $CFG;
+                $fixturedir = $CFG->dirroot . '/mod/accredible/tests/fixtures/mockapi/v1/';
+                $filepath = $fixturedir . $jsonpath;
+                return json_decode(file_get_contents($filepath));
+            }
+        };
+
+        $this->user = $this->getDataGenerator()->create_user();
+        $this->course = $this->getDataGenerator()->create_course();
+    }
+
+    /**
+     * Post credential evidence test
+     */
+    public function test_accredible_post_evidence() {
+        // When the throw_error is FALSE and the response is successful.
+        $mockclient1 = $this->getMockBuilder('client')
+            ->setMethods(['post'])
+            ->getMock();
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('evidence_items/create_success.json');
+
+        // Expect to call the endpoint once with url and reqdata.
+        $url = 'https://api.accredible.com/v1/credentials/1/evidence_items';
+        $evidenceitem = array(
+            "string_object" => "100",
+            "description" => "Quiz",
+            "custom" => true,
+            "category" => "grade"
+        );
+        $reqdata = json_encode(array("evidence_item" => $evidenceitem));
+
+        $mockclient1->expects($this->once())
+            ->method('post')
+            ->with($this->equalTo($url),
+                   $this->equalTo($reqdata))
+            ->willReturn($resdata);
+
+        // Expect to return resdata.
+        $api = new apirest($mockclient1);
+        $evidenceitems = new evidenceitems($api);
+        $result = $evidenceitems->accredible_post_evidence(1, $evidenceitem, false);
+        $this->assertEquals($result, null);
+
+        // When the throw_error is FALSE and the response is NOT successful.
+        $mockclient2 = $this->getMockBuilder('client')
+            ->setMethods(['post'])
+            ->getMock();
+        $mockclient2->error = 'The requested URL returned error: 401 Unauthorized';
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('unauthorized_error.json');
+
+        $mockclient2->expects($this->once())
+            ->method('post')
+            ->with($this->equalTo($url),
+                   $this->equalTo($reqdata))
+            ->willReturn($resdata);
+
+        // Expect to not throwing an exception.
+        $api = new apirest($mockclient2);
+        $evidenceitems = new evidenceitems($api);
+        $result = $evidenceitems->accredible_post_evidence(1, $evidenceitem, false);
+        $this->assertEquals($result, null);
+
+        // When the throw_error is TRUE and the response is NOT successful.
+        $mockclient3 = $this->getMockBuilder('client')
+            ->setMethods(['post'])
+            ->getMock();
+        $mockclient3->error = 'The requested URL returned error: 401 Unauthorized';
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('unauthorized_error.json');
+
+        $mockclient3->expects($this->once())
+            ->method('post')
+            ->with($this->equalTo($url),
+                   $this->equalTo($reqdata))
+            ->willReturn($resdata);
+
+        // Expect to return resdata without throwing an exception.
+        $foundexception = false;
+        $api = new apirest($mockclient3);
+        $evidenceitems = new evidenceitems($api);
+        try {
+            $evidenceitems->accredible_post_evidence(1, $evidenceitem, true, $api);
+        } catch (\moodle_exception $error) {
+            $foundexception = true;
+        }
+        $this->assertTrue($foundexception);
+    }
+
+    /**
+     * Post credential evidence from essay answers test
+     */
+    public function test_accredible_post_essay_answers() {
+        global $DB;
+
+        $evidenceitems = new evidenceitems();
+
+        // When there are not quizes.
+        $result = $evidenceitems->accredible_post_essay_answers(1, 1, 1);
+
+        $this->assertEmpty($DB->get_records('quiz'));
+        $this->assertEquals($result, null);
+
+        // When there are not quiz attempts.
+        $this->create_quiz_module(1);
+        $result = $evidenceitems->accredible_post_essay_answers(1, 1, 1);
+
+        $this->assertEmpty($DB->get_records('quiz_attempts'));
+        $this->assertEquals($result, null);
+
+        // When there are no quiz attemps for user.
+        $quiz = $this->create_quiz_module(1);
+        $this->create_quiz_grades($quiz->id, 2, 5);
+        $result = $evidenceitems->accredible_post_essay_answers(1, 1, 1);
+
+        $this->assertEquals($result, null);
+
+        // When there are quiz attemps for user.
+        $quiz = $this->create_quiz_module(1, $this->user->id);
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+
+        $category = $questiongenerator->create_question_category();
+        $question = $questiongenerator->create_question('shortanswer', null, array('category' => $category->id));
+        quiz_add_quiz_question($question->id, $quiz);
+
+        $questionusageid = $this->create_question_usage();
+        $this->create_question_attempt($quiz->id, $this->user->id, $questionusageid, $question->id);
+        $this->create_quiz_attempt($quiz->id, $this->user->id, $questionusageid);
+
+        $mockclient1 = $this->getMockBuilder('client')
+            ->setMethods(['post'])
+            ->getMock();
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('evidence_items/create_success.json');
+
+        // Expect to call the endpoint once with url and reqdata.
+        $url = 'https://api.accredible.com/v1/credentials/1/evidence_items';
+        $questionsoutput = "<style>#main {  max-width: 780px;margin-left: auto;";
+        $questionsoutput .= "margin-right: auto;margin-top: 50px;margin-bottom: 80px; font-family: Arial;} ";
+        $questionsoutput .= "h1, h5 {   text-align: center;} ";
+        $questionsoutput .= ".answer { border: 1px solid grey; padding: 20px; font-size: 14px; ";
+        $questionsoutput .= "line-height: 22px; margin-bottom:30px; margin-top:30px;} ";
+        $questionsoutput .= "p {font-size: 14px; line-height: 18px;} </style>";
+        $questionsoutput .= "<div id='main'>";
+        $questionsoutput .= "<h1>" . $quiz->name . "</h1>";
+        $questionsoutput .= "<h5>Time Taken: 0 second</h5><div class='answer'></div></div>";
+        $evidenceitem = array(
+            "evidence_item" => array(
+                "description"   => $quiz->name,
+                "string_object" => $questionsoutput,
+                "hidden"        => true
+            )
+        );
+        $reqdata = json_encode($evidenceitem);
+
+        $mockclient1->expects($this->once())
+            ->method('post')
+            ->with($this->equalTo($url), $this->equalTo($reqdata))
+            ->willReturn($resdata);
+
+        $api = new apirest($mockclient1);
+        $evidenceitems = new evidenceitems($api);
+        $result = $evidenceitems->accredible_post_essay_answers($this->user->id, 1, 1);
+        $this->assertEquals($result, null);
+    }
+
+    /**
+     * Post credential evidence test
+     */
+    public function test_accredible_course_duration_evidence() {
+        global $DB;
+
+        $evidenceitems = new evidenceitems();
+
+        // When there are not enrolments.
+        $result = $evidenceitems->accredible_course_duration_evidence(1, 1, 1);
+        $this->assertEquals($result, null);
+
+        // When there is enrolment with timestart 0.
+        $enrolid = $this->create_enrolment(1);
+        $enrolid = $this->create_user_enrolment($enrolid, 2, 0);
+
+        $result = $evidenceitems->accredible_course_duration_evidence(2, 1, 1);
+        $this->assertEquals($result, null);
+
+        // When there is enrolment with timestart.
+        $enrolid = $this->create_enrolment(1);
+        $enrolid = $this->create_user_enrolment($enrolid, $this->user->id, time());
+
+        $mockclient1 = $this->getMockBuilder('client')
+            ->setMethods(['post'])
+            ->getMock();
+
+        // Mock API response data.
+        $resdata = $this->mockapi->resdata('evidence_items/create_success.json');
+
+        // Expect to call the endpoint once with url and reqdata.
+        $url = 'https://api.accredible.com/v1/credentials/1/evidence_items';
+
+        $mockclient1->expects($this->once())
+            ->method('post')
+            ->with($this->equalTo($url))
+            ->willReturn($resdata);
+
+        $api = new apirest($mockclient1);
+        $evidenceitems = new evidenceitems($api);
+
+        $result = $evidenceitems->accredible_course_duration_evidence($this->user->id, 1, 1);
+        $this->assertEquals($result, null);
+    }
+
+    /**
+     * Create enrolment test
+     *
+     * @param int $courseid
+     */
+    private function create_enrolment($courseid) {
+        global $DB;
+        $data = array("courseid" => $courseid);
+        return $DB->insert_record('enrol', $data);
+    }
+
+    /**
+     * Create user enrolment test
+     *
+     * @param int $enrolid
+     * @param int $userid
+     * @param date $timestart
+     */
+    private function create_user_enrolment($enrolid, $userid, $timestart) {
+        global $DB;
+        $data = array("enrolid" => $enrolid, "userid" => $userid, "modifierid" => $userid, "timestart" => $timestart);
+        return $DB->insert_record('user_enrolments', $data);
+    }
+
+    /**
+     * Create quiz module test
+     *
+     * @param int $courseid
+     * @param int $userid
+     */
+    private function create_quiz_module($courseid, $userid = null) {
+        $quiz = array("course" => $courseid, "grade" => 10);
+        if ($userid) {
+            $quiz["userid"] = $userid;
+        }
+        return $this->getDataGenerator()->create_module('quiz', $quiz);
+    }
+
+    /**
+     * Create question attempt
+     *
+     * @param int $quizid
+     * @param int $userid
+     * @param int $questionusageid
+     */
+    private function create_quiz_attempt($quizid, $userid, $questionusageid) {
+        global $DB;
+        $data = array("quiz"            => $quizid,
+                      "userid"          => $userid,
+                      "attempt"         => 1,
+                      "uniqueid"        => $questionusageid,
+                      "layout"          => "layout",
+                      "state"           => "finished");
+        return $DB->insert_record('quiz_attempts', $data);
+    }
+
+    /**
+     * Create question attempt
+     *
+     * @param int $quizid
+     * @param int $userid
+     * @param int $questionusageid
+     * @param int $questionid
+     */
+    private function create_question_attempt($quizid, $userid, $questionusageid, $questionid) {
+        global $DB;
+        $data = array("quiz"            => $quizid,
+                      "userid"          => $userid,
+                      "slot"            => 1,
+                      "questionusageid" => $questionusageid,
+                      "questionid"      => $questionid,
+                      "maxmark"         => 10,
+                      "behaviour"       => "manualgraded",
+                      "minfraction"     => 1,
+                      "maxfraction"     => 1,
+                      "timemodified"    => time());
+        $DB->insert_record('question_attempts', $data);
+    }
+
+    /**
+     * Create question usage
+     */
+    private function create_question_usage() {
+        global $DB;
+        $data = array("id" => 1, "contextid" => 1);
+        return $DB->insert_record('question_usages', $data);
+    }
+
+    /**
+     * Create quiz grades test
+     *
+     * @param int $quizid
+     * @param int $userid
+     * @param int $grade
+     */
+    private function create_quiz_grades($quizid, $userid, $grade) {
+        global $DB;
+        $quizgrade = array("quiz" => $quizid, "userid" => $userid, "grade" => $grade);
+        return $DB->insert_record('quiz_grades', $quizgrade);
+    }
+}

--- a/tests/local/mod_accredible_evidenceitems_test.php
+++ b/tests/local/mod_accredible_evidenceitems_test.php
@@ -242,7 +242,7 @@ class mod_accredible_evidenceitems_test extends \advanced_testcase {
         $enrolid = $this->create_enrolment(1);
         $this->create_user_enrolment($enrolid, $this->user->id, strtotime('2022-04-19'));
 
-        $result = $evidenceitems->course_duration_evidence($this->user->id, 1, 1, date("Y-m-d", strtotime('2022-04-17')));
+        $result = $evidenceitems->course_duration_evidence($this->user->id, 1, 1, strtotime('2022-04-17'));
         $this->assertEquals($result, null);
 
         // When there is enrolment with completed time < enrol start.
@@ -283,7 +283,7 @@ class mod_accredible_evidenceitems_test extends \advanced_testcase {
         $api = new apirest($mockclient1);
         $evidenceitems = new evidenceitems($api);
 
-        $result = $evidenceitems->course_duration_evidence($user->id, 1, 1, date("Y-m-d", strtotime('2022-04-17')));
+        $result = $evidenceitems->course_duration_evidence($user->id, 1, 1, strtotime('2022-04-17'));
         $this->assertEquals($result, null);
     }
 

--- a/tests/mod_accredible_locallib_test.php
+++ b/tests/mod_accredible_locallib_test.php
@@ -15,10 +15,6 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace mod_accredible;
-defined('MOODLE_INTERNAL') || die();
-
-global $CFG;
-require_once($CFG->dirroot . '/mod/accredible/locallib.php');
 
 use mod_accredible\apirest\apirest;
 


### PR DESCRIPTION
This PR removes `$CFG->prefix` from custom SQL
queries to use `{}` instead.

Also I have created a new class in the `local` folder
to manage the credential evidence items and moved
related methods from locallib to the new class.