### PR TITLE
DGR-254 - Update plugin schema

### DIFF
--- a/backup/moodle2/backup_accredible_stepslib.php
+++ b/backup/moodle2/backup_accredible_stepslib.php
@@ -36,7 +36,8 @@ class backup_accredible_activity_structure_step extends backup_activity_structur
         // XML nodes declaration.
         $accredible = new backup_nested_element('accredible', array('id'), array(
             'name', 'course', 'achievementid', 'description', 'finalquiz', 'passinggrade', 'completionactivities',
-            'includegradeattribute', 'gradeattributegradeitemid', 'gradeattributekeyname', 'groupid', 'finalgradetopass', 'attributemapping'));
+            'includegradeattribute', 'gradeattributegradeitemid', 'gradeattributekeyname', 'groupid',
+            'finalgradetopass', 'attributemapping'));
 
         // Data sources - non-user data.
         $accredible->set_source_table('accredible', array('id' => backup::VAR_ACTIVITYID));

--- a/backup/moodle2/backup_accredible_stepslib.php
+++ b/backup/moodle2/backup_accredible_stepslib.php
@@ -36,7 +36,7 @@ class backup_accredible_activity_structure_step extends backup_activity_structur
         // XML nodes declaration.
         $accredible = new backup_nested_element('accredible', array('id'), array(
             'name', 'course', 'achievementid', 'description', 'finalquiz', 'passinggrade', 'completionactivities',
-            'includegradeattribute', 'gradeattributegradeitemid', 'gradeattributekeyname', 'groupid'));
+            'includegradeattribute', 'gradeattributegradeitemid', 'gradeattributekeyname', 'groupid', 'finalgradetopass', 'attributemapping'));
 
         // Data sources - non-user data.
         $accredible->set_source_table('accredible', array('id' => backup::VAR_ACTIVITYID));

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/accredible/db" VERSION="20220609" COMMENT="XMLDB file for Moodle mod/accredible"
+<XMLDB PATH="mod/accredible/db" VERSION="20240416" COMMENT="XMLDB file for Moodle mod/accredible"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -20,6 +20,8 @@
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="certificatename" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="groupid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="finalgradetopass" TYPE="int" LENGTH="3" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="attributemapping" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for certificate"/>

--- a/db/install.xml
+++ b/db/install.xml
@@ -20,7 +20,7 @@
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="certificatename" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="groupid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="finalgradetopass" TYPE="int" LENGTH="3" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="finalgradetopass" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="attributemapping" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -164,5 +164,28 @@ function xmldb_accredible_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2022060900, 'accredible');
     }
 
+    if ($oldversion < 2024041600) {
+        // Define field finalgradetopass to be added to accredible.
+        $table = new xmldb_table('accredible');
+        $field = new xmldb_field('finalgradetopass', XMLDB_TYPE_INTEGER, '3', null, XMLDB_NOTNULL, null, null, 'groupid');
+
+        // Conditionally launch add field finalgradetopass.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field attributemapping to be added to accredible.
+        $table = new xmldb_table('accredible');
+        $field = new xmldb_field('attributemapping', XMLDB_TYPE_TEXT, null, null, null, null, null, 'finalgradetopass');
+
+        // Conditionally launch add field attributemapping.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Accredible savepoint reached.
+        upgrade_mod_savepoint(true, 2024041600, 'accredible');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -167,7 +167,7 @@ function xmldb_accredible_upgrade($oldversion=0) {
     if ($oldversion < 2024041600) {
         // Define field finalgradetopass to be added to accredible.
         $table = new xmldb_table('accredible');
-        $field = new xmldb_field('finalgradetopass', XMLDB_TYPE_INTEGER, '3', null, XMLDB_NOTNULL, null, null, 'groupid');
+        $field = new xmldb_field('finalgradetopass', XMLDB_TYPE_INTEGER, '3', null, XMLDB_NOTNULL, null, '0', 'groupid');
 
         // Conditionally launch add field finalgradetopass.
         if (!$dbman->field_exists($table, $field)) {

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023070300; // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2024041600; // The current module version (Date: YYYYMMDDXX).
 $plugin->requires  = 2014051200; // Requires this Moodle version.
 $plugin->cron      = 0; // Period for cron to check this module (secs).
 $plugin->component = 'mod_accredible';


### PR DESCRIPTION
This PR;
- Adds `finalgradetopass` and `attributemapping` to our Accredible plugin schema.
  - `finalgradetopass` (decimal): To store the minimum course final grade to pass for auto-issuance on course completion
  - `attributemapping` (text): To store the dynamic custom attribute mapping

- Updates the backup schema structure to include the newly added fields

The `install.xml`, `upgrade.php`, and `version.php` file changes were derived from the `XMLDB editor` in Moodle. 

See attached recording in the ticket [DGR-254](https://accredible.atlassian.net/browse/DGR-254)
