### PR TITLE
DGR-261 - [Moodle] attribute mapping schema validation

### DIFF
--- a/classes/local/attributemapping.php
+++ b/classes/local/attributemapping.php
@@ -78,11 +78,6 @@ class attributemapping {
     public function get_db_object() {
         // Remove empty values.
         $object = (object) array_filter((array) $this);
-
-        // Replace accredibleattribute key with accredible_attribute.
-        unset($object->accredibleattribute);
-        $object->accredible_attribute = $this->accredibleattribute;
-
         return $object;
     }
 

--- a/classes/local/attributemapping.php
+++ b/classes/local/attributemapping.php
@@ -51,7 +51,8 @@ class attributemapping {
     public $accredibleattribute;
 
     /**
-     * AttributeMapping constructor.
+     * Constructor method
+     *
      * @param string $table
      * @param string $accredibleattribute
      * @param string|null $field
@@ -68,6 +69,16 @@ class attributemapping {
         $this->field = $field;
         $this->id = $id;
         $this->accredibleattribute = $accredibleattribute;
+    }
+
+    /**
+     * Converts the attributemapping object into a string
+     * @return string stringified version of attributemapping object
+     */
+    public function get_text_content() {
+        // Filter empty values.
+        $object = array_filter((array) $this);
+        return json_encode($object);
     }
 
     /**

--- a/classes/local/attributemapping.php
+++ b/classes/local/attributemapping.php
@@ -72,13 +72,18 @@ class attributemapping {
     }
 
     /**
-     * Converts the attributemapping object into a string
-     * @return string stringified version of attributemapping object
+     * Updates the attributemapping object into an object suitable for saving into the db.
+     * @return stdObject updated attributemapping object
      */
-    public function get_text_content() {
-        // Filter empty values.
-        $object = array_filter((array) $this);
-        return json_encode($object);
+    public function get_db_object() {
+        // Remove empty values.
+        $object = (object) array_filter((array) $this);
+
+        // Replace accredibleattribute key with accredible_attribute.
+        unset($object->accredibleattribute);
+        $object->accredible_attribute = $this->accredibleattribute;
+
+        return $object;
     }
 
     /**
@@ -117,7 +122,7 @@ class attributemapping {
      */
     private function validate_id($table, $id) {
         if (($table === "user_info_field" || $table === "customfield_field") && $id === null) {
-            throw new \InvalidArgumentException("Id is required for table '$table'");
+            throw new \InvalidArgumentException("Id is required for the '$table' table");
         }
     }
 

--- a/classes/local/attributemapping.php
+++ b/classes/local/attributemapping.php
@@ -1,0 +1,113 @@
+<?php
+// This file is part of the Accredible Certificate module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_accredible\local;
+
+/**
+ * Local functions related to attributemapping.
+ *
+ * @package    mod_accredible
+ * @subpackage accredible
+ * @copyright  Accredible <dev@accredible.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class attributemapping {
+
+    /**
+     * The name of the table (must be one of 'course', 'user_info_field', 'customfield_field')
+     * @var string table
+     */
+    public $table;
+
+    /**
+     * The field name in the table (null for 'user_info_field' and 'customfield_field')
+     * @var string|null field
+     */
+    public $field;
+
+    /**
+     * The unique identifier (required for 'user_info_field' and 'customfield_field')
+     * @var int|null id
+     */
+    public $id;
+
+    /**
+     * The name of the attribute in Accredible
+     * @var string accredibleattribute
+     */
+    public $accredibleattribute;
+
+    /**
+     * AttributeMapping constructor.
+     * @param string $table
+     * @param string $accredibleattribute
+     * @param string|null $field
+     * @param int|null $id
+     * @throws InvalidArgumentException If any validation fails
+     */
+    public function __construct($table, $accredibleattribute, $field = null, $id = null) {
+        // Handle validation.
+        $this->validate_table($table);
+        $this->validate_field($table, $field);
+        $this->validate_id($table, $id);
+
+        $this->table = $table;
+        $this->field = $field;
+        $this->id = $id;
+        $this->accredibleattribute = $accredibleattribute;
+    }
+
+    /**
+     * Validates if the provided table name is valid.
+     * @param string $table
+     * @throws InvalidArgumentException If the table name is invalid
+     */
+    private function validate_table($table) {
+        $validtables = ["course", "user_info_field", "customfield_field"];
+        if (!in_array($table, $validtables)) {
+            throw new \InvalidArgumentException("Invalid table value");
+        }
+    }
+
+    /**
+     * Validates if the field value is correct based on the table name.
+     * @param string $table
+     * @param string|null $field
+     * @throws InvalidArgumentException If the field name is invalid
+     */
+    private function validate_field($table, $field) {
+        if ($table === "course") {
+            // Valid fields for the 'course' table.
+            $validfields = ["fullname", "shortname", "startdate", "enddate"];
+            if (!in_array($field, $validfields)) {
+                throw new \InvalidArgumentException("Invalid field value for the 'course' table");
+            }
+        }
+    }
+
+    /**
+     * Validates if the ID is required and correct based on the table name.
+     * @param string $table
+     * @param int|null $id
+     * @throws InvalidArgumentException If the ID is invalid
+     */
+    private function validate_id($table, $id) {
+        if (($table === "user_info_field" || $table === "customfield_field") && $id === null) {
+            throw new \InvalidArgumentException("Id is required for table '$table'");
+        }
+    }
+
+}

--- a/classes/local/attributemapping_list.php
+++ b/classes/local/attributemapping_list.php
@@ -82,7 +82,9 @@ class attributemapping_list {
         $uniqueattributes = [];
         foreach ($attributemappings as $attributemapping) {
             if (in_array($attributemapping->accredibleattribute, $uniqueattributes)) {
-                throw new \InvalidArgumentException("Duplicate accredibleattribute found: {$attributemapping->accredibleattribute}");
+                throw new \InvalidArgumentException(
+                    "Duplicate accredibleattribute found: {$attributemapping->accredibleattribute}"
+                );
             }
             $uniqueattributes[] = $attributemapping->accredibleattribute;
         }

--- a/classes/local/attributemapping_list.php
+++ b/classes/local/attributemapping_list.php
@@ -67,7 +67,7 @@ class attributemapping_list {
      */
     public function get_text_content() {
         $jsonarray = array();
-        foreach($this->attributemappings as $mapping) {
+        foreach ($this->attributemappings as $mapping) {
             $jsonarray[] = $mapping->get_db_object();
         }
         return json_encode($jsonarray);

--- a/classes/local/attributemapping_list.php
+++ b/classes/local/attributemapping_list.php
@@ -1,0 +1,91 @@
+<?php
+// This file is part of the Accredible Certificate module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_accredible\local;
+
+use mod_accredible\apirest\apirest;
+use mod_accredible\local\attributemapping;
+
+/**
+ * Local functions related to attributemapping list.
+ *
+ * @package    mod_accredible
+ * @subpackage accredible
+ * @copyright  Accredible <dev@accredible.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class attributemapping_list {
+    /**
+     * The apirest object used to call API requests.
+     * @var apirest
+     */
+    private $apirest;
+
+    /**
+     * Array of attribute mapping objects.
+     * @var $attributemapping[] attributemappings
+     */
+    public $attributemappings = array();
+
+
+    /**
+     * Constructor method
+     *
+     * @param attributemapping[] $attributemappings an array of mappings.
+     * @param stdObject $apirest a mock apirest for testing.
+     */
+    public function __construct($attributemappings, $apirest = null) {
+        // Handle validation.
+        $this->validate_attributemapping($attributemappings);
+
+        $this->attributemappings = $attributemappings;
+
+        // A mock apirest is passed when unit testing.
+        if ($apirest) {
+            $this->apirest = $apirest;
+        } else {
+            $this->apirest = new apirest();
+        }
+    }
+
+    /**
+     * Converts the attributemappings array into a string
+     * @return string stringified version of attributemappings array
+     */
+    public function get_text_content() {
+        $jsonarray = array();
+        foreach($this->attributemappings as $mapping) {
+            $jsonarray[] = $mapping->get_db_object();
+        }
+        return json_encode($jsonarray);
+    }
+
+    /**
+     * Validates a list of attribute mappings to ensure no duplicate accredible attributes exist.
+     * @param attributemapping[] $attributemappings array of attribute mapping objects.
+     * @throws InvalidArgumentException If a duplicate accredible attribute is found.
+     */
+    private function validate_attributemapping($attributemappings) {
+        $uniqueattributes = [];
+        foreach ($attributemappings as $attributemapping) {
+            $accredibleattribute = $attributemapping->accredibleattribute;
+            if (in_array($accredibleattribute, $uniqueattributes)) {
+                throw new \InvalidArgumentException("Duplicate accredibleattribute found: {$accredibleattribute}");
+            }
+            $uniqueattributes[] = $accredibleattribute;
+        }
+    }
+}

--- a/classes/local/attributemapping_list.php
+++ b/classes/local/attributemapping_list.php
@@ -81,11 +81,10 @@ class attributemapping_list {
     private function validate_attributemapping($attributemappings) {
         $uniqueattributes = [];
         foreach ($attributemappings as $attributemapping) {
-            $accredibleattribute = $attributemapping->accredibleattribute;
-            if (in_array($accredibleattribute, $uniqueattributes)) {
-                throw new \InvalidArgumentException("Duplicate accredibleattribute found: {$accredibleattribute}");
+            if (in_array($attributemapping->accredibleattribute, $uniqueattributes)) {
+                throw new \InvalidArgumentException("Duplicate accredibleattribute found: {$attributemapping->accredibleattribute}");
             }
-            $uniqueattributes[] = $accredibleattribute;
+            $uniqueattributes[] = $attributemapping->accredibleattribute;
         }
     }
 }

--- a/tests/local/mod_accredible_attributemapping_list_test.php
+++ b/tests/local/mod_accredible_attributemapping_list_test.php
@@ -64,15 +64,29 @@ class mod_accredible_attributemapping_list_test extends \advanced_testcase {
      * Test whether it converts attributemappings into a string.
      */
     public function test_get_text_content() {
-        // When attributemapping_list has a valid value
+        // When attributemapping_list has a valid value.
         $mapping1 = new attributemapping('course', 'grade', 'fullname');
         $mapping2 = new attributemapping('user_info_field', 'user_id', 'mooodle_user_id', 100);
 
-        $mapping1string = '{"table":"'.$mapping1->table.'","field":"'.$mapping1->field.'","accredibleattribute":"'.$mapping1->accredibleattribute.'"}';
-        $mapping2string = '{"table":"'.$mapping2->table.'","field":"'.$mapping2->field.'","id":'.$mapping2->id.',"accredibleattribute":"'.$mapping2->accredibleattribute.'"}';
+        $format1 = '{"table":"%s","field":"%s","accredibleattribute":"%s"}';
+        $mapping1string = sprintf(
+            $format1,
+            $mapping1->table,
+            $mapping1->field,
+            $mapping1->accredibleattribute
+        );
+
+        $format2 = '{"table":"%s","field":"%s","id":%d,"accredibleattribute":"%s"}';
+        $mapping2string = sprintf(
+            $format2,
+            $mapping2->table,
+            $mapping2->field,
+            $mapping2->id,
+            $mapping2->accredibleattribute
+        );
 
         $result = "[$mapping1string,$mapping2string]";
-        
+
         // Expect strings to match.
         $attributemappinglist = new attributemapping_list(array($mapping1, $mapping2));
         $this->assertEquals($result, $attributemappinglist->get_text_content());

--- a/tests/local/mod_accredible_attributemapping_list_test.php
+++ b/tests/local/mod_accredible_attributemapping_list_test.php
@@ -68,8 +68,8 @@ class mod_accredible_attributemapping_list_test extends \advanced_testcase {
         $mapping1 = new attributemapping('course', 'grade', 'fullname');
         $mapping2 = new attributemapping('user_info_field', 'user_id', 'mooodle_user_id', 100);
 
-        $mapping1string = '{"table":"'.$mapping1->table.'","field":"'.$mapping1->field.'","accredible_attribute":"'.$mapping1->accredibleattribute.'"}';
-        $mapping2string = '{"table":"'.$mapping2->table.'","field":"'.$mapping2->field.'","id":'.$mapping2->id.',"accredible_attribute":"'.$mapping2->accredibleattribute.'"}';
+        $mapping1string = '{"table":"'.$mapping1->table.'","field":"'.$mapping1->field.'","accredibleattribute":"'.$mapping1->accredibleattribute.'"}';
+        $mapping2string = '{"table":"'.$mapping2->table.'","field":"'.$mapping2->field.'","id":'.$mapping2->id.',"accredibleattribute":"'.$mapping2->accredibleattribute.'"}';
 
         $result = "[$mapping1string,$mapping2string]";
         

--- a/tests/local/mod_accredible_attributemapping_list_test.php
+++ b/tests/local/mod_accredible_attributemapping_list_test.php
@@ -1,0 +1,80 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_accredible\local;
+
+/**
+ * Unit tests for mod/accredible/classes/local/attributemapping_list.php
+ *
+ * @package    mod_accredible
+ * @subpackage accredible
+ * @category   test
+ * @copyright  Accredible <dev@accredible.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_accredible_attributemapping_list_test extends \advanced_testcase {
+    /**
+     * Setup testcase.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Test whether it validates attribute mappings.
+     */
+    public function test_validate_attributemapping() {
+        // When $accredibleattribute in mappings is duplicated.
+        $accredibleattribute = 'grade';
+        $mapping1 = new attributemapping('course', $accredibleattribute, 'fullname');
+        $mapping2 = new attributemapping('user_info_field', $accredibleattribute, 'mooodle_user_id', 100);
+
+        // Expect to raise an exception.
+        $foundexception = false;
+        try {
+            $attributemappinglist = new attributemapping_list(array($mapping1, $mapping2));
+        } catch (\InvalidArgumentException $error) {
+            $foundexception = true;
+        }
+        $this->assertTrue($foundexception);
+
+        // When $accredibleattribute in mappings is unique.
+        $mapping2->accredibleattribute = 'user_id';
+
+        // Expect attribute mappings to be set.
+        $attributemappinglist = new attributemapping_list(array($mapping1, $mapping2));
+        $this->assertEquals($mapping1, $attributemappinglist->attributemappings[0]);
+        $this->assertEquals($mapping2, $attributemappinglist->attributemappings[1]);
+    }
+
+    /**
+     * Test whether it converts attributemappings into a string.
+     */
+    public function test_get_text_content() {
+        // When attributemapping_list has a valid value
+        $mapping1 = new attributemapping('course', 'grade', 'fullname');
+        $mapping2 = new attributemapping('user_info_field', 'user_id', 'mooodle_user_id', 100);
+
+        $mapping1string = '{"table":"'.$mapping1->table.'","field":"'.$mapping1->field.'","accredible_attribute":"'.$mapping1->accredibleattribute.'"}';
+        $mapping2string = '{"table":"'.$mapping2->table.'","field":"'.$mapping2->field.'","id":'.$mapping2->id.',"accredible_attribute":"'.$mapping2->accredibleattribute.'"}';
+
+        $result = "[$mapping1string,$mapping2string]";
+        
+        // Expect strings to match.
+        $attributemappinglist = new attributemapping_list(array($mapping1, $mapping2));
+        $this->assertEquals($result, $attributemappinglist->get_text_content());
+    }
+}

--- a/tests/local/mod_accredible_attributemapping_list_test.php
+++ b/tests/local/mod_accredible_attributemapping_list_test.php
@@ -35,6 +35,7 @@ class mod_accredible_attributemapping_list_test extends \advanced_testcase {
 
     /**
      * Test whether it validates attribute mappings.
+     * @covers  ::validate_attributemapping
      */
     public function test_validate_attributemapping() {
         // When $accredibleattribute in mappings is duplicated.
@@ -62,6 +63,7 @@ class mod_accredible_attributemapping_list_test extends \advanced_testcase {
 
     /**
      * Test whether it converts attributemappings into a string.
+     * @covers  ::get_text_content
      */
     public function test_get_text_content() {
         // When attributemapping_list has a valid value.

--- a/tests/local/mod_accredible_attributemapping_test.php
+++ b/tests/local/mod_accredible_attributemapping_test.php
@@ -35,6 +35,7 @@ class mod_accredible_attributemapping_test extends \advanced_testcase {
 
     /**
      * Test whether it validates table property.
+     * @covers  ::validate_table
      */
     public function test_validate_table() {
         // When $table has an invalid value.
@@ -61,6 +62,7 @@ class mod_accredible_attributemapping_test extends \advanced_testcase {
 
     /**
      * Test whether it validates field property.
+     * @covers  ::validate_field
      */
     public function test_validate_field() {
         // When $table is course and $field has an invalid value.
@@ -88,6 +90,7 @@ class mod_accredible_attributemapping_test extends \advanced_testcase {
 
     /**
      * Test whether it validates id property.
+     * @covers  ::validate_id
      */
     public function test_validate_id() {
         // When $table is user_info_field and has no $id value.
@@ -135,6 +138,7 @@ class mod_accredible_attributemapping_test extends \advanced_testcase {
 
     /**
      * Test whether it returns an object with no null/empty values.
+     * @covers  ::get_db_object
      */
     public function test_get_db_object() {
         // When $table has a valid value.

--- a/tests/local/mod_accredible_attributemapping_test.php
+++ b/tests/local/mod_accredible_attributemapping_test.php
@@ -134,18 +134,22 @@ class mod_accredible_attributemapping_test extends \advanced_testcase {
     }
 
     /**
-     * Test whether it returns an attributemapping string.
+     * Test whether it returns an updated attributemapping object.
      */
-    public function test_get_text_content() {
+    public function test_get_db_object() {
         // When $table has a valid value.
         $table = 'course';
         $field = 'fullname';
         $accredibleattribute = 'grade';
 
-        $stringobject = '{"table":"'.$table.'","field":"'.$field.'","accredibleattribute":"'.$accredibleattribute.'"}';
+        $dbobject = (object) [
+            'table' => $table,
+            'field' => $field,
+            'accredible_attribute' => $accredibleattribute
+        ];
 
         // Expect strings to match.
         $attributemapping = new attributemapping($table, $accredibleattribute, $field);
-        $this->assertEquals($stringobject, $attributemapping->get_text_content());
+        $this->assertEquals($dbobject, $attributemapping->get_db_object());
     }
 }

--- a/tests/local/mod_accredible_attributemapping_test.php
+++ b/tests/local/mod_accredible_attributemapping_test.php
@@ -132,4 +132,20 @@ class mod_accredible_attributemapping_test extends \advanced_testcase {
         $attributemapping = new attributemapping($table, $accredibleattribute, $field, $id);
         $this->assertEquals($id, $attributemapping->id);
     }
+
+    /**
+     * Test whether it returns an attributemapping string.
+     */
+    public function test_get_text_content() {
+        // When $table has a valid value.
+        $table = 'course';
+        $field = 'fullname';
+        $accredibleattribute = 'grade';
+
+        $stringobject = '{"table":"'.$table.'","field":"'.$field.'","accredibleattribute":"'.$accredibleattribute.'"}';
+
+        // Expect strings to match.
+        $attributemapping = new attributemapping($table, $accredibleattribute, $field);
+        $this->assertEquals($stringobject, $attributemapping->get_text_content());
+    }
 }

--- a/tests/local/mod_accredible_attributemapping_test.php
+++ b/tests/local/mod_accredible_attributemapping_test.php
@@ -134,7 +134,7 @@ class mod_accredible_attributemapping_test extends \advanced_testcase {
     }
 
     /**
-     * Test whether it returns an updated attributemapping object.
+     * Test whether it returns an object with no null/empty values.
      */
     public function test_get_db_object() {
         // When $table has a valid value.
@@ -142,14 +142,8 @@ class mod_accredible_attributemapping_test extends \advanced_testcase {
         $field = 'fullname';
         $accredibleattribute = 'grade';
 
-        $result = (object) [
-            'table' => $table,
-            'field' => $field,
-            'accredible_attribute' => $accredibleattribute
-        ];
-
-        // Expect strings to match.
-        $attributemapping = new attributemapping($table, $accredibleattribute, $field);
-        $this->assertEquals($result, $attributemapping->get_db_object());
+        // Expect returned object to not have id
+        $attributemapping = new attributemapping($table, $accredibleattribute, $field, null);
+        $this->assertTrue(!property_exists($attributemapping->get_db_object(), 'id'));
     }
 }

--- a/tests/local/mod_accredible_attributemapping_test.php
+++ b/tests/local/mod_accredible_attributemapping_test.php
@@ -142,7 +142,7 @@ class mod_accredible_attributemapping_test extends \advanced_testcase {
         $field = 'fullname';
         $accredibleattribute = 'grade';
 
-        $dbobject = (object) [
+        $result = (object) [
             'table' => $table,
             'field' => $field,
             'accredible_attribute' => $accredibleattribute
@@ -150,6 +150,6 @@ class mod_accredible_attributemapping_test extends \advanced_testcase {
 
         // Expect strings to match.
         $attributemapping = new attributemapping($table, $accredibleattribute, $field);
-        $this->assertEquals($dbobject, $attributemapping->get_db_object());
+        $this->assertEquals($result, $attributemapping->get_db_object());
     }
 }

--- a/tests/local/mod_accredible_attributemapping_test.php
+++ b/tests/local/mod_accredible_attributemapping_test.php
@@ -142,7 +142,7 @@ class mod_accredible_attributemapping_test extends \advanced_testcase {
         $field = 'fullname';
         $accredibleattribute = 'grade';
 
-        // Expect returned object to not have id
+        // Expect returned object to not have id.
         $attributemapping = new attributemapping($table, $accredibleattribute, $field, null);
         $this->assertTrue(!property_exists($attributemapping->get_db_object(), 'id'));
     }

--- a/tests/local/mod_accredible_attributemapping_test.php
+++ b/tests/local/mod_accredible_attributemapping_test.php
@@ -1,0 +1,135 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_accredible\local;
+
+/**
+ * Unit tests for mod/accredible/classes/local/attributemapping.php
+ *
+ * @package    mod_accredible
+ * @subpackage accredible
+ * @category   test
+ * @copyright  Accredible <dev@accredible.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_accredible_attributemapping_test extends \advanced_testcase {
+    /**
+     * Setup testcase.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Test whether it validates table property.
+     */
+    public function test_validate_table() {
+        // When $table has an invalid value.
+        $table = 'invalid';
+        $accredibleattribute = 'grade';
+
+        // Expect to raise an exception.
+        $foundexception = false;
+        try {
+            $attributemapping = new attributemapping($table, $accredibleattribute);
+        } catch (\InvalidArgumentException $error) {
+            $foundexception = true;
+        }
+        $this->assertTrue($foundexception);
+
+        // When $table has a valid value.
+        $table = 'course';
+        $field = 'fullname';
+
+        // Expect $table value to be set.
+        $attributemapping = new attributemapping($table, $accredibleattribute, $field);
+        $this->assertEquals($table, $attributemapping->table);
+    }
+
+    /**
+     * Test whether it validates field property.
+     */
+    public function test_validate_field() {
+        // When $table is course and $field has an invalid value.
+        $table = 'course';
+        $field = 'incorrect_field';
+        $accredibleattribute = 'grade';
+
+        // Expect to raise an exception.
+        $foundexception = false;
+        try {
+            $attributemapping = new attributemapping($table, $accredibleattribute, $field);
+        } catch (\InvalidArgumentException $error) {
+            $foundexception = true;
+        }
+        $this->assertTrue($foundexception);
+
+        // When $table is course and $field has a valid value.
+        $table = 'course';
+        $field = 'fullname';
+
+        // Expect $field value to be set.
+        $attributemapping = new attributemapping($table, $accredibleattribute, $field);
+        $this->assertEquals($field, $attributemapping->field);
+    }
+
+    /**
+     * Test whether it validates id property.
+     */
+    public function test_validate_id() {
+        // When $table is user_info_field and has no $id value.
+        $table = 'user_info_field';
+        $field = 'age';
+        $accredibleattribute = 'grade';
+
+        // Expect to raise an exception.
+        $foundexception = false;
+        try {
+            $attributemapping = new attributemapping($table, $accredibleattribute, $field);
+        } catch (\InvalidArgumentException $error) {
+            $foundexception = true;
+        }
+        $this->assertTrue($foundexception);
+
+        // When $table is customfield_field and has no $id value.
+        $table = 'customfield_field';
+
+        // Expect to raise an exception.
+        $foundexception = false;
+        try {
+            $attributemapping = new attributemapping($table, $accredibleattribute, $field);
+        } catch (\InvalidArgumentException $error) {
+            $foundexception = true;
+        }
+        $this->assertTrue($foundexception);
+
+        // When $table is user_info_field and $id has value.
+        $table = 'user_info_field';
+        $id = 120;
+
+        // Expect $id value to be set.
+        $attributemapping = new attributemapping($table, $accredibleattribute, $field, $id);
+        $this->assertEquals($id, $attributemapping->id);
+
+        // When $table is customfield_field and $id has value.
+        $table = 'customfield_field';
+        $id = 100;
+
+        // Expect $id value to be set.
+        $attributemapping = new attributemapping($table, $accredibleattribute, $field, $id);
+        $this->assertEquals($id, $attributemapping->id);
+    }
+}


### PR DESCRIPTION
This PR adds;
- `attributemapping` class with validation + unit tests
- `attributemapping_list` class with validation + unit tests
---
`attributemapping` class validation
- `table` 
    - Required
    - Allowed values: `course`, `user_info_field`, and `customfield_field`
- `id`
   - Required only when **table** is either `user_info_field` or `customfield_field`
- `field`
   - Required only when **table** is `course`
     - Allowed values: `fullname`, `shortname`, `startdate`, and `enddate`
- `accredibleattribute`
   - Required
---
`attributemapping_list` class validation
- `accredibleattribute`
   - Must be unique within the **attributemapping** array