### PR TITLE
Use a volume mount for mariadb container

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Please refer to [Writing PHPUnit tests](https://docs.moodle.org/dev/Writing_PHPU
 After running Moodle with the Accredible plugin, log in to the Moodle container.
 
 ```
-docker exec -it moodle-mod_accredible_moodle_1 bash
+docker exec -it moodle-mod_accredible-moodle-1 bash
 ```
 
 Add the following lines to `config.php`.
@@ -222,7 +222,7 @@ php /bitnami/moodle/admin/tool/phpunit/cli/init.php
 Log in to the Moodle container.
 
 ```
-docker exec -it moodle-mod_accredible_moodle_1 bash
+docker exec -it moodle-mod_accredible-moodle-1 bash
 ```
 
 Run unit tests of this plugin using the following command.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ If the error keeps happening, it would be better to clear the containers with th
 
 ```
 docker-compose down -v
-rm -rf .docker/volumes/mariadb/data
 ```
 
 and set it up again from the beginning.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   mariadb:
     image: docker.io/bitnami/mariadb:10.5
@@ -10,7 +9,7 @@ services:
       - MARIADB_COLLATE=utf8mb4_unicode_ci
     volumes:
       # For persistence of the MariaDB data
-      - './.docker/volumes/mariadb:/bitnami/mariadb'
+      - 'mariadb_data:/bitnami/mariadb'
 
   moodle:
     build: .
@@ -43,3 +42,4 @@ services:
 volumes:
   moodle_data:
   moodledata_data:
+  mariadb_data:


### PR DESCRIPTION
This PR:
- Replaces the bind mount for mariadb container with a volume mount. (This will prevent issues like [this](https://github.com/docker/for-mac/issues/6807) & now we only have to use  `docker-compose down -v` for cleanup)
- Fixes container name in `exec` commands