### PR TITLE
DGR-581: Fix course custom field dropdown attribute mapping

### DIFF
--- a/classes/local/accredible.php
+++ b/classes/local/accredible.php
@@ -188,6 +188,8 @@ class accredible {
             return $this->date($value);
         } else if ($customfield->type === 'textarea') {
             return strip_tags($value);
+        } else if ($customfield->type === 'select') {
+            return $this->customfield_selected_option($value, $customfield->configdata);
         } else {
             return $value;
         }
@@ -246,6 +248,33 @@ class accredible {
         }
         $accredibledateformat = 'Y-m-d';
         return date($accredibledateformat, $value);
+    }
+
+    /**
+     * Retrieves the selected option from a custom field based on its stored value and configuration data.
+     *
+     * @param mixed $value The stored value of the custom field which typically represents the selected index.
+     * @param string $configdata JSON encoded string containing the configuration of the custom field, including options.
+     * @return string|null The label of the selected option, or null if the index is out of range or invalid.
+     */
+    private function customfield_selected_option($value, $configdata) {
+        if ((int) $value === 0) {
+            return;
+        }
+        $index = (int) $value - 1;
+        $decoded = json_decode($configdata);
+        $options = $this->split_by_line($decoded->options);
+        return $options[$index];
+    }
+
+    /**
+     * Splits a text string into an array of lines.
+     *
+     * @param string $text The text to be split.
+     * @return array An array of strings, each representing a line in the input text.
+     */
+    private function split_by_line($text) {
+        return preg_split("/\r\n|\n|\r/", $text);
     }
 
     /**

--- a/tests/local/mod_accredible_accredible_test.php
+++ b/tests/local/mod_accredible_accredible_test.php
@@ -307,6 +307,45 @@ class mod_accredible_accredible_test extends \advanced_testcase {
             'Moodle Course Custom Field' => '2024-02-09'
         ], $result);
 
+        // When saving a record with a course custom field mapping (select).
+        // Insert custom field definition.
+        $customfieldfieldselect = new \stdClass();
+        $customfieldfieldselect->shortname = 'select';
+        $customfieldfieldselect->name = 'Select Field';
+        $customfieldfieldselect->type = 'select';
+        $customfieldfieldselect->timecreated = time();
+        $customfieldfieldselect->timemodified = time();
+        $configdata = '{"required":"0","uniquevalues":"0","options":"test1\r\ntest2\r\ntest3","defaultvalue":"test1"}';
+        $customfieldfieldselect->configdata = $configdata;
+        $customfieldfieldidselect = $DB->insert_record('customfield_field', $customfieldfieldselect);
+
+        // Insert custom field data.
+        $customfielddataselect = new \stdClass();
+        $customfielddataselect->fieldid = $customfieldfieldidselect;
+        $customfielddataselect->instanceid = $course->id;
+        $customfielddataselect->value = 2;
+        $customfielddataselect->valueformat = 0;
+        $customfielddataselect->timecreated = time();
+        $customfielddataselect->timemodified = time();
+        $customfielddataidselect = $DB->insert_record('customfield_data', $customfielddataselect);
+
+        $overrides = new \stdClass();
+        $overrides->course = $course->id;
+        $overrides->coursecustomfieldmapping = [
+            [
+                'id' => $customfieldfieldidselect,
+                'accredibleattribute' => 'Moodle Course Custom Field'
+            ]
+        ];
+        $post = $this->generatepostobject($overrides);
+        $accredibleid = $this->accredible->save_record($post);
+        $accrediblerecord = $DB->get_record('accredible', ['id' => $accredibleid]);
+
+        $result = $this->accredible->load_credential_custom_attributes($accrediblerecord, $user->id);
+        $this->assertEquals([
+            'Moodle Course Custom Field' => 'test2'
+        ], $result);
+
         // When saving a record with user info field mapping (datetime).
         $overrides = new \stdClass();
         $overrides->course = $course->id;


### PR DESCRIPTION
This PR fixes a bug with the course custom field attribute mapping when the data type is "dropdown". It was mapping the selected option integer value to credentials but now it's fixed and properly maps the selected string value.

FYI: Unlike course custom dropdown fields, user profile dropdown fields don't have this issue as they are stored and handled differently by Moodle.