### PR TITLE
DGR-582: Bug-fix to disable grade attribute mapping when unchecked

### DIFF
--- a/classes/local/accredible.php
+++ b/classes/local/accredible.php
@@ -39,14 +39,16 @@ class accredible {
     public function save_record($post, $existingrecord = null) {
         global $DB;
 
+        $includegradeattribute = $post->includegradeattribute ?? 0;
+        $gradeattributechecked = $includegradeattribute !== 0;
         $dbrecord = (object) [
             'completionactivities' => $post->completionactivities ?? null,
             'name' => $post->name,
             'finalquiz' => $post->finalquiz,
             'passinggrade' => $post->passinggrade,
-            'includegradeattribute' => $post->includegradeattribute ?? 0,
-            'gradeattributegradeitemid' => $post->gradeattributegradeitemid,
-            'gradeattributekeyname' => $post->gradeattributekeyname,
+            'includegradeattribute' => $includegradeattribute,
+            'gradeattributegradeitemid' => $gradeattributechecked ? $post->gradeattributegradeitemid : null,
+            'gradeattributekeyname' => $gradeattributechecked ? $post->gradeattributekeyname : null,
             'groupid' => $post->groupid,
             'attributemapping' => $this->build_attribute_mapping_list($post),
             'timecreated' => time()

--- a/tests/local/mod_accredible_accredible_test.php
+++ b/tests/local/mod_accredible_accredible_test.php
@@ -134,6 +134,50 @@ class mod_accredible_accredible_test extends \advanced_testcase {
 
         $result = $this->accredible->save_record($post);
         $this->assertEquals(1, $result);
+
+        // When grade attribute mapping is enabled with mapping fields selected.
+        $overrides = new \stdClass();
+        $overrides->includegradeattribute = 1;
+        $overrides->gradeattributegradeitemid = 10;
+        $overrides->gradeattributekeyname = 'Final Grade';
+        $post = $this->generatepostobject($overrides);
+
+        $DB = $this->createMock(\moodle_database::class);
+        $DB->expects($this->once())
+            ->method('insert_record')
+            ->with(
+                'accredible',
+                $this->callback(function($subject) {
+                    return $subject->gradeattributegradeitemid === 10 &&
+                        $subject->gradeattributekeyname === 'Final Grade';
+                })
+            )
+            ->willReturn(1);
+
+        $result = $this->accredible->save_record($post);
+        $this->assertEquals(1, $result);
+
+        // When grade attribute mapping is disabled with mapping fields selected.
+        $overrides = new \stdClass();
+        $overrides->includegradeattribute = 0;
+        $overrides->gradeattributegradeitemid = 10;
+        $overrides->gradeattributekeyname = 'Final Grade';
+        $post = $this->generatepostobject($overrides);
+
+        $DB = $this->createMock(\moodle_database::class);
+        $DB->expects($this->once())
+            ->method('insert_record')
+            ->with(
+                'accredible',
+                $this->callback(function($subject) {
+                    return $subject->gradeattributegradeitemid === null &&
+                        $subject->gradeattributekeyname === null;
+                })
+            )
+            ->willReturn(1);
+
+        $result = $this->accredible->save_record($post);
+        $this->assertEquals(1, $result);
     }
 
 


### PR DESCRIPTION
This PR fixes a bug in the grade attribute mapping deactivation behavior. When the option "Yes, include grade in Credential" is unchecked on the form, it now resets the attribute mapping field values on save to deactivate the grade mapping functionality.