### PR TITLE
Issue #114: Added parameter check to prevent deprecated warnings

### DIFF
--- a/classes/client/client.php
+++ b/classes/client/client.php
@@ -118,7 +118,6 @@ class client {
             debugging('<div style="padding-top: 70px; font-size: 0.9rem;"><b>ACCREDIBLE API ERROR</b> ' .
                 $curl->error . '<br />' . $method . ' ' . $url . '</div>', DEBUG_DEVELOPER);
         };
-
-        return json_decode($response);
+        return $response ? json_decode($response) : null;
     }
 }

--- a/locallib.php
+++ b/locallib.php
@@ -498,7 +498,7 @@ function serialize_completion_array($completionarray) {
  * @param stdObject $completionobject
  */
 function unserialize_completion_array($completionobject) {
-    return (array)unserialize(base64_decode( $completionobject ));
+    return $completionobject ? (array)unserialize(base64_decode( $completionobject )) : null;
 }
 
 /**


### PR DESCRIPTION
Closes Issue #114.

After re-running PHPUnit tests with these fixes:
`vendor/bin/phpunit mod/accredible/tests/client/mod_accredible_client_test.php`
```
Moodle 4.5.2+ (Build: 20250304), 1140177889307d0919c4898047c473efe3e604bc
Php: 8.1.28, mysqli: 8.0.37, OS: Linux 6.8.0-52-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

....                                                                4 / 4 (100%)

Time: 00:42.510, Memory: 82.50 MB

OK (4 tests, 6 assertions)
```